### PR TITLE
Rename plugin 'Firefox Newtab' to 'firefox-newtab'

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "plugins": [
     {
-      "name": "Firefox Newtab",
+      "name": "firefox-newtab",
       "path": "plugins/newtab",
       "description": "Skills and tools for Firefox Home/New Tab development"
     }


### PR DESCRIPTION
Fix #4 