### PR TITLE
Add Widgets Scaffolding skill

### DIFF
--- a/plugins/newtab/skills/widgets-scaffold/SKILL.md
+++ b/plugins/newtab/skills/widgets-scaffold/SKILL.md
@@ -1,0 +1,82 @@
+---
+description: Scaffolds a new Firefox New Tab widget with JSX, SCSS, prefs, telemetry, Widgets.jsx integration, and a draft test file. Use when the user wants to add a new widget to the New Tab page.
+---
+
+# New Tab Widget Scaffold
+
+Widgets live in `browser/extensions/newtab/content-src/components/Widgets/`.
+
+## Workflow
+
+### Step 1 — Gather requirements
+
+Ask the user to run the requirements script first:
+
+```
+python3 .claude/skills/newtab-widget-scaffold/scripts/gather_requirements.py
+```
+
+The script asks all required questions and prints a widget spec summary.
+Wait for the user to paste that summary before proceeding.
+
+### Step 2 — Plan
+
+Enter plan mode. Using the spec and the example in
+`references/ExampleWidget/`, propose the full list of files to
+create/modify before writing anything. Read `references/notes.md` for
+non-obvious requirements and gotchas.
+
+Files touched by every widget:
+1. `ActivityStream.sys.mjs` — register prefs (**do this first, then run `./mach build faster` before proceeding**)
+2. `Widgets/{Name}/{Name}.jsx` — new widget component
+3. `Widgets/{Name}/_{Name}.scss` — widget styles
+4. `Widgets/Widgets.jsx` — import, enabled logic, null guard, JSX render
+5. `Widgets/_Widgets.scss` — add CSS class to `:has()` selector
+6. `content-src/styles/activity-stream.scss` — add `@import`
+7. `stylelint-rollouts.config.js` (repo root) — add the new widget's SCSS path in alphabetical order alongside the other widget entries
+8. `Base.jsx`, `CustomizeMenu.jsx`, `ContentSection.jsx` — Customize panel toggle
+9. `browser/locales/en-US/browser/newtab/newtab.ftl` — FTL strings
+
+Additional files if the spec requires them:
+- `common/Actions.mjs` + `common/Reducers.sys.mjs` — only if Redux state is needed
+
+### Step 3 — Scaffold
+
+After plan approval, implement all files end-to-end without stopping between
+edits. Do not pause to summarize progress or ask for confirmation mid-scaffold.
+Work through every file in the plan in sequence, replicating the patterns in
+`references/ExampleWidget/` and substituting values from the spec.
+
+Only stop if you hit a genuine blocker (e.g. a file doesn't exist where expected,
+or the codebase structure differs from what the plan assumed). In that case,
+explain what you found and what decision is needed before continuing.
+
+### Step 4 — Follow-up
+
+Remind the user:
+- Add any remaining Fluent strings for context menu items and widget body labels
+- Run `./mach lint`
+
+Then explain how to enable the widget:
+
+**Option A — `about:config`**
+
+Set both of these to `true`:
+- `browser.newtabpage.activity-stream.widgets.{widgetKey}.enabled`
+- `browser.newtabpage.activity-stream.widgets.system.{widgetKey}.enabled`
+
+**Option B — Nimbus trainhop**
+
+1. Install [Nimbus devtools](https://github.com/mozilla-extensions/nimbus-devtools/releases/tag/release%2Fv0.3.0)
+2. Choose "Feature configuration enrollment" on the left side
+3. Opt into an experiment for `newtabTrainhop` with:
+
+```json
+{
+  "type": "widgets",
+  "payload": {
+    "enabled": true,
+    "{widgetKey}Enabled": true
+  }
+}
+```

--- a/plugins/newtab/skills/widgets-scaffold/references/ExampleWidget/ExampleWidget.jsx
+++ b/plugins/newtab/skills/widgets-scaffold/references/ExampleWidget/ExampleWidget.jsx
@@ -1,0 +1,168 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+// eslint-disable-next-line no-unused-vars
+import React, { useCallback, useRef } from "react";
+import { useSelector, batch } from "react-redux";
+import { actionCreators as ac, actionTypes as at } from "common/Actions.mjs";
+import { useIntersectionObserver } from "../../../lib/utils";
+
+// Only present for interactive widgets. Remove entirely for view-only widgets.
+const USER_ACTION_TYPES = {
+  DO_THING: "do_thing",
+  DO_OTHER_THING: "do_other_thing",
+};
+
+// Constants for any widget-specific prefs read inside this component.
+// Omit if no extra prefs beyond enabled/system.enabled.
+const PREF_EXAMPLE_WIDGET_MAX_ITEMS = "widgets.exampleWidget.maxItems";
+
+function ExampleWidget({
+  dispatch,
+  handleUserInteraction, // omit this param for view-only widgets
+  isMaximized,
+  widgetsMayBeMaximized,
+}) {
+  const prefs = useSelector(state => state.Prefs.values);
+  // If the widget has a Redux state slice:
+  // const widgetData = useSelector(state => state.ExampleWidget);
+
+  const impressionFired = useRef(false);
+  const widgetSize = isMaximized ? "medium" : "small";
+
+  const handleIntersection = useCallback(() => {
+    if (impressionFired.current) {
+      return;
+    }
+    impressionFired.current = true;
+    dispatch(
+      ac.AlsoToMain({
+        type: at.WIDGETS_IMPRESSION,
+        data: {
+          widget_name: "example_widget",
+          widget_size: widgetsMayBeMaximized ? widgetSize : "medium",
+        },
+      })
+    );
+  }, [dispatch, widgetSize, widgetsMayBeMaximized]);
+
+  const widgetRef = useIntersectionObserver(handleIntersection);
+
+  // Call handleUserInteraction("<widgetKey>") after any interaction that should
+  // mark the widget as "interacted with" for the feature highlight flow.
+  const handleInteraction = useCallback(
+    () => handleUserInteraction("exampleWidget"),
+    [handleUserInteraction]
+  );
+
+  function handleDoThing() {
+    batch(() => {
+      // Your main action dispatch goes here, e.g. ac.AlsoToMain(...)
+
+      dispatch(
+        ac.OnlyToMain({
+          type: at.WIDGETS_USER_EVENT,
+          data: {
+            widget_name: "example_widget",
+            widget_source: "widget",
+            user_action: USER_ACTION_TYPES.DO_THING,
+            widget_size: widgetsMayBeMaximized ? widgetSize : "medium",
+          },
+        })
+      );
+    });
+    handleInteraction();
+  }
+
+  function handleExampleWidgetHide() {
+    batch(() => {
+      dispatch(
+        ac.OnlyToMain({
+          type: at.SET_PREF,
+          data: { name: "widgets.exampleWidget.enabled", value: false },
+        })
+      );
+      dispatch(
+        ac.OnlyToMain({
+          type: at.WIDGETS_ENABLED,
+          data: {
+            widget_name: "example_widget",
+            widget_source: "context_menu",
+            enabled: false,
+            widget_size: widgetsMayBeMaximized ? widgetSize : "medium",
+          },
+        })
+      );
+    });
+    // Only call handleInteraction() here if the widget is interactive.
+    handleInteraction();
+  }
+
+  function handleLearnMore() {
+    batch(() => {
+      dispatch(
+        ac.OnlyToMain({
+          type: at.OPEN_LINK,
+          data: { url: "https://support.mozilla.org/kb/firefox-new-tab-widgets" },
+        })
+      );
+      dispatch(
+        ac.OnlyToMain({
+          type: at.WIDGETS_USER_EVENT,
+          data: {
+            widget_name: "example_widget",
+            widget_source: "context_menu",
+            user_action: "learn_more",
+            widget_size: widgetsMayBeMaximized ? widgetSize : "medium",
+          },
+        })
+      );
+    });
+  }
+
+  const maxItems = prefs[PREF_EXAMPLE_WIDGET_MAX_ITEMS];
+
+  return (
+    <article
+      className={`example-widget${isMaximized ? " is-maximized" : ""}`}
+      ref={el => {
+        widgetRef.current = [el];
+      }}
+    >
+      <div className="example-widget-title-wrapper">
+        <h3 className="newtab-example-widget-title">Example Widget</h3>
+        <div className="example-widget-context-menu-wrapper">
+          <moz-button
+            className="example-widget-context-menu-button"
+            iconSrc="chrome://global/skin/icons/more.svg"
+            menuId="example-widget-context-menu"
+            type="ghost"
+          />
+          <panel-list id="example-widget-context-menu">
+            {/* Additional context menu items from spec go here, before Hide */}
+            <panel-item
+              data-l10n-id="newtab-widget-menu-hide"
+              onClick={handleExampleWidgetHide}
+            />
+            <panel-item
+              data-l10n-id="newtab-example-widget-menu-learn-more"
+              onClick={handleLearnMore}
+            />
+          </panel-list>
+        </div>
+      </div>
+
+      {/* Widget body */}
+      <div className="example-widget-body">
+        <p>Widget content goes here. Max items: {maxItems}</p>
+        <moz-button
+          data-l10n-id="newtab-example-widget-do-thing"
+          onClick={handleDoThing}
+        />
+      </div>
+    </article>
+  );
+}
+
+export { ExampleWidget };

--- a/plugins/newtab/skills/widgets-scaffold/references/ExampleWidget/_ExampleWidget.scss
+++ b/plugins/newtab/skills/widgets-scaffold/references/ExampleWidget/_ExampleWidget.scss
@@ -1,0 +1,58 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/* stylelint-disable stylelint-plugin-mozilla/use-design-tokens */
+
+.example-widget {
+  @include newtab-card-style;
+
+  grid-column: span 1;
+  width: var(--newtab-card-grid-layout-width);
+
+  .has-sections-grid & {
+    width: var(--newtab-card-width-medium);
+  }
+
+  border-radius: var(--border-radius-large);
+  padding: var(--space-medium);
+  height: var(--newtab-card-height);
+  display: flex;
+  flex-direction: column;
+  box-shadow: var(--box-shadow-card);
+}
+
+.example-widget-title-wrapper {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-block-end: var(--space-xsmall);
+
+  h3 {
+    margin-block: 0;
+    font-weight: var(--font-weight);
+    font-size: var(--font-size-root);
+  }
+}
+
+.example-widget-context-menu-wrapper {
+  opacity: 0;
+  pointer-events: none;
+}
+
+.example-widget:hover,
+.example-widget:focus-within {
+  .example-widget-context-menu-wrapper {
+    opacity: 1;
+    pointer-events: auto;
+  }
+}
+
+// Widget-specific styles below.
+// Use design system tokens only — no hardcoded colors or spacing values.
+.example-widget-body {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-small);
+}

--- a/plugins/newtab/skills/widgets-scaffold/references/notes.md
+++ b/plugins/newtab/skills/widgets-scaffold/references/notes.md
@@ -1,0 +1,160 @@
+# Widget Scaffolding Notes
+
+Things that are non-obvious from the ExampleWidget alone. Only update this file
+when a gotcha changes — if the example shows it clearly, it doesn't belong here.
+
+## Build order matters
+
+Generate and register the prefs in `ActivityStream.sys.mjs` **first**, then
+run `./mach build faster` before scaffolding the remaining files. The enablement
+logic in `Widgets.jsx` reads prefs from the Redux store — if they aren't
+registered by the build yet, the widget won't appear even when Nimbus/trainhop
+is configured.
+
+## CustomizeMenu.jsx is a required passthrough
+
+`Base.jsx` passes `mayHave*Widget` props to `<CustomizeMenu>`, which forwards
+them to `<ContentSection>`. If you add the prop in `Base.jsx` and `ContentSection.jsx`
+but forget `CustomizeMenu.jsx`, the toggle silently never appears.
+
+Files to touch for the Customize panel toggle (all four are required):
+
+1. `Base.jsx` — compute `mayHave{Name}Widget` and `{widgetKey}Enabled`
+2. `CustomizeMenu.jsx` — forward the prop
+3. `ContentSection.jsx` — add the `switch` case and render the `moz-toggle`
+4. `browser/locales/en-US/browser/newtab/newtab.ftl` — add the toggle label string
+
+## FTL file location and string formats
+
+All widget strings go in `browser/locales/en-US/browser/newtab/newtab.ftl`.
+Not the `webext-glue/locales/` path (that's a different, generated file).
+
+Add a `##` group comment only at the start of the section, not at the end.
+A `##` with no messages after it is a lint error (GC04).
+
+String formats differ by type — do not mix them up:
+
+**Customize panel toggle** — uses `.label` attribute:
+
+```ftl
+newtab-custom-widget-{css-class}-toggle =
+    .label = {Display Name}
+```
+
+**Context menu Learn More** — plain string, no attribute:
+
+```ftl
+newtab-{css-class}-widget-menu-learn-more = Learn more
+```
+
+**Context menu Hide** — shared string, already exists, do not add it:
+
+```ftl
+newtab-widget-menu-hide = Hide
+```
+
+## handleUserInteraction is conditional
+
+Only include `handleUserInteraction` in the component signature and call it if
+the widget has body interactions (Q5 = yes). For view-only widgets, omit it
+from both the destructure and the JSX props in `Widgets.jsx`.
+
+## batch() on every multi-dispatch
+
+Any handler that dispatches two or more actions must wrap them in `batch()`
+to avoid intermediate renders. This includes `handleHide`, user event handlers,
+and any action that pairs a state change with a telemetry dispatch.
+
+## Nimbus trainhop naming convention
+
+The trainhop key follows camelCase + "Enabled" suffix:
+
+- `prefs.trainhopConfig?.widgets?.{widgetKey}Enabled`
+
+Match this exactly — a typo here means the Nimbus experiment path silently
+does nothing.
+
+## Full enabled logic blocks (Widgets.jsx and Base.jsx)
+
+These two patterns are not visible from the ExampleWidget component file alone.
+
+**Widgets.jsx** — pref constants and enabled expression to add alongside existing widgets:
+
+```js
+const PREF_WIDGETS_{WIDGET_KEY}_ENABLED = "widgets.{widgetKey}.enabled";
+const PREF_WIDGETS_SYSTEM_{WIDGET_KEY}_ENABLED = "widgets.system.{widgetKey}.enabled";
+```
+
+```js
+const nimbus{ComponentName}TrainhopEnabled =
+  prefs.trainhopConfig?.widgets?.{widgetKey}Enabled;
+const {widgetKey}Enabled =
+  (nimbus{ComponentName}TrainhopEnabled ||
+    prefs[PREF_WIDGETS_SYSTEM_{WIDGET_KEY}_ENABLED]) &&
+  prefs[PREF_WIDGETS_{WIDGET_KEY}_ENABLED];
+```
+
+**Base.jsx** — nimbus variables and `mayHave` flag to add alongside existing widgets:
+
+```js
+const nimbus{ComponentName}Enabled = prefs.widgetsConfig?.{widgetKey}Enabled;
+const nimbus{ComponentName}TrainhopEnabled =
+  prefs.trainhopConfig?.widgets?.{widgetKey}Enabled;
+const mayHave{ComponentName}Widget =
+  prefs["widgets.system.{widgetKey}.enabled"] ||
+  nimbus{ComponentName}Enabled ||
+  nimbus{ComponentName}TrainhopEnabled;
+```
+
+Also add `{widgetKey}Enabled: prefs["widgets.{widgetKey}.enabled"]` to the
+`enabledWidgets` object in `Base.jsx`, and pass `mayHave{ComponentName}Widget`
+as a prop to `<CustomizeMenu>`.
+
+**Widget component itself** — only needed when the component has its own
+`return null` guard (i.e. special enable conditions from Q9). Read the trainhop
+variable directly from prefs inside the component, mirroring `WeatherForecast.jsx`:
+
+```js
+const nimbus{ComponentName}TrainhopEnabled =
+  prefs.trainhopConfig?.widgets?.{widgetKey}Enabled;
+const {widgetKey}WidgetEnabled =
+  nimbus{ComponentName}TrainhopEnabled ||
+  prefs["widgets.system.{widgetKey}.enabled"];
+
+if (!{widgetKey}WidgetEnabled || /* other special conditions */) {
+  return null;
+}
+```
+
+For standard widgets without special conditions, skip this — the guard lives
+entirely in `Widgets.jsx` and the component always renders when mounted.
+
+## Learn More URL
+
+Always point to: `https://support.mozilla.org/kb/firefox-new-tab-widgets`
+
+Do not create a widget-specific SUMO page — all widgets share this URL.
+
+## null guard in Widgets.jsx
+
+The `if (!(listsEnabled || timerEnabled || ...))` guard controls whether the
+entire widget section renders. Add your new `{widgetKey}Enabled` to this OR
+expression, otherwise hiding all other widgets will leave your widget orphaned
+in an empty container.
+
+## `_Widgets.scss` `:has()` selector
+
+The `.widgets-container` rule uses `:has(.lists), :has(.focus-timer)` to apply
+layout when any widget is present. Add your widget's CSS class to this selector
+or the container layout won't activate when only your widget is visible.
+
+## Toast string (pending)
+
+`newtab-toast-widgets-hidden` is not yet landed. Once it lands and we rebase,
+wire it up to the hide action in the individual widget's hide handler.
+
+## Redux state (optional)
+
+Only add a Redux slice if the widget needs cross-tab persistence or complex
+shared state. Simple local state (`useState`) is preferable for transient UI.
+When in doubt, don't add Redux — it can always be added later.

--- a/plugins/newtab/skills/widgets-scaffold/scripts/gather_requirements.py
+++ b/plugins/newtab/skills/widgets-scaffold/scripts/gather_requirements.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+"""Gather widget requirements interactively and print a spec summary for Claude."""
+
+import re
+import sys
+
+
+def ask(prompt, allow_empty=False):
+    while True:
+        answer = input(f"\n{prompt}\n> ").strip()
+        if answer or allow_empty:
+            return answer
+        print("Please provide an answer.")
+
+
+def to_kebab(camel):
+    """Convert camelCase to kebab-case."""
+    s = re.sub(r"([A-Z])", r"-\1", camel)
+    return s.lower().lstrip("-")
+
+
+def to_snake(camel):
+    """Convert camelCase to snake_case."""
+    s = re.sub(r"([A-Z])", r"_\1", camel)
+    return s.lower().lstrip("_")
+
+
+def to_upper_snake(camel):
+    return to_snake(camel).upper()
+
+
+def main():
+    print("=" * 60)
+    print("New Tab Widget Requirements Gatherer")
+    print("=" * 60)
+    print("Answer each question to generate a widget spec for Claude.")
+
+    # Q1
+    display_name = ask(
+        "Q1. What is the human-readable display name of the widget?\n    (e.g. 'Reading List', 'Quick Notes')"
+    )
+
+    # Q2
+    widget_key = ask(
+        "Q2. What is the camelCase key for this widget?\n    (e.g. 'readingList', 'quickNotes') — used in pref names and telemetry"
+    )
+
+    # Q3 — inferred
+    css_class = to_kebab(widget_key)
+    print(
+        f"\n[Q3 inferred] CSS class: '{css_class}'  (derived from camelCase key — override below if needed)"
+    )
+    override = input(
+        f"> Press Enter to accept '{css_class}', or type a different value: "
+    ).strip()
+    if override:
+        css_class = override
+
+    component_name = widget_key[0].upper() + widget_key[1:]
+    telemetry_name = to_snake(widget_key)
+    widget_key_upper = to_upper_snake(widget_key)
+
+    # Q4
+    extra_menu_items = ask(
+        "Q4. Any extra context menu items beyond 'Hide' and 'Learn More'?\n"
+        "    List them (e.g. 'Change Location, Toggle Unit') or type 'none'.",
+        allow_empty=True,
+    )
+
+    # Q5
+    interactive_raw = ask(
+        "Q5. Will users interact with the widget body itself (clicking buttons, typing, etc.)?\n"
+        "    Or is it view-only? Answer 'yes' (interactive) or 'no' (view-only)."
+    )
+    is_interactive = interactive_raw.lower().startswith("y")
+
+    # Q6 — conditional
+    user_actions = ""
+    if is_interactive:
+        user_actions = ask(
+            "Q6. What are the user action type strings for body interactions?\n"
+            "    (e.g. 'add_item, toggle_item, delete_item')"
+        )
+
+    # Q7
+    extra_prefs = ask(
+        "Q7. Any widget-specific prefs beyond 'enabled' / 'system.enabled'?\n"
+        "    List each with type and default (e.g. 'widgets.readingList.maxItems, int, 20') or 'none'.",
+        allow_empty=True,
+    )
+
+    # Q8
+    redux_state_raw = ask(
+        "Q8. Does this widget need its own Redux state slice?\n"
+        "    'yes' + brief shape description, or 'no'."
+    )
+    has_redux = redux_state_raw.lower().startswith("y")
+    redux_shape = redux_state_raw[3:].strip() if has_redux else ""
+
+    # Q9
+    special_conditions = ask(
+        "Q9. Any special enable conditions beyond 'enabled' + 'system.enabled'?\n"
+        "    Describe them, or type 'none'.",
+        allow_empty=True,
+    )
+
+    # --- Print summary ---
+    print("\n" + "=" * 60)
+    print("WIDGET SPEC — hand this to Claude to enter plan mode")
+    print("=" * 60)
+    print(f"  displayName:    {display_name}")
+    print(f"  componentName:  {component_name}")
+    print(f"  widgetKey:      {widget_key}")
+    print(f"  cssClass:       {css_class}")
+    print(f"  telemetryName:  {telemetry_name}")
+    print(f"  WIDGET_KEY:     {widget_key_upper}")
+    print(f"  interactive:    {'yes' if is_interactive else 'no (view-only)'}")
+    if is_interactive and user_actions:
+        print(f"  userActions:    {user_actions}")
+    print(f"  extraMenuItems: {extra_menu_items or 'none'}")
+    print(f"  extraPrefs:     {extra_prefs or 'none'}")
+    print(f"  reduxState:     {'yes — ' + redux_shape if has_redux else 'no'}")
+    print(f"  specialConditions: {special_conditions or 'none'}")
+    print("=" * 60)
+    print("\nNow enter plan mode: /newtab-widget-scaffold with the spec above.")
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except KeyboardInterrupt:
+        print("\nAborted.")
+        sys.exit(1)


### PR DESCRIPTION
🚨Note that I've moved things over from Phabricator: https://phabricator.services.mozilla.com/D285428

🟢  Just run `/widgets-scaffold` to get it running!

---

We're going to be growing our number of widgets as we go, and creating a widgets scaffold skill for Claude should help us speed things up/reduce errors when initially setting up a widget.

### What it does
Interactively scaffolds a new Firefox New Tab widget from scratch by gathering
requirements and generating all necessary boilerplate files.

---

### Step 1 — Requirements gathering (script)
Asks the user to run a Python script that collects all widget requirements:

```
python3 .claude/skills/newtab-widget-scaffold/scripts/gather_requirements.py
```


The script asks questions one at a time and prints a widget spec summary, which the user pastes back to Claude before proceeding.

---

### Step 2 — Plan
Enter plan mode. Using the spec and the reference files in `references/ExampleWidget/` and `references/notes.md`, propose the full list of files to create/modify before writing anything.

Files touched by every widget:

| File | Purpose |
|------|---------|
| `ActivityStream.sys.mjs` | Registers prefs **(done first, then `./mach build faster`)** |
| `Widgets/{Name}/{Name}.jsx` | Main component (impression tracking, context menu, telemetry) |
| `Widgets/{Name}/_{Name}.scss` | Widget card styles using design tokens |
| `Widgets/Widgets.jsx` | Import, enabled logic, null guard, JSX render |
| `Widgets/_Widgets.scss` | Adds widget CSS class to `:has()` layout selectors |
| `content-src/styles/activity-stream.scss` | Adds SCSS `@import` |
| `stylelint-rollouts.config.js` | Adds the new widget's SCSS path in alphabetical order |
| `Base.jsx` + `CustomizeMenu.jsx` + `ContentSection.jsx` | Customize panel toggle (4-file passthrough chain) |
| `browser/locales/en-US/browser/newtab/newtab.ftl` | Fluent strings for toggle label and context menu items |

Additional files if the spec requires them:
- `common/Actions.mjs` + `common/Reducers.sys.mjs` — only if Redux state is needed

---

### Step 3 — Scaffold
After plan approval, implement all files end-to-end without stopping. Patterns and gotchas are in the `references/` folder — `ExampleWidget/` provides concrete code examples, `notes.md` documents non-obvious requirements (build order, FTL string formats, enabled logic blocks, etc.).

---

### Step 4 — Manual follow-up
- Add any remaining Fluent strings for context menu items and widget body labels
- Run `./mach lint`

---

### Step 5 — How to enable the widget

**Option A — `about:config`**

Set both of these to `true`:
- `browser.newtabpage.activity-stream.widgets.{widgetKey}.enabled`
- `browser.newtabpage.activity-stream.widgets.system.{widgetKey}.enabled`

**Option B — Nimbus trainhop config**

Install Nimbus devtools, choose "Feature configuration enrollment", and opt into
`newtabTrainhop` with:

```json
{
  "type": "widgets",
  "payload": {
    "enabled": true,
    "{widgetKey}Enabled": true
  }
}
