### PR TITLE
Improve widget scaffold with lessons from Word of the Day widget

### DIFF
--- a/plugins/newtab/skills/widgets-scaffold/SKILL.md
+++ b/plugins/newtab/skills/widgets-scaffold/SKILL.md
@@ -33,9 +33,12 @@ Files touched by every widget:
 4. `Widgets/Widgets.jsx` — import, enabled logic, null guard, JSX render
 5. `Widgets/_Widgets.scss` — add CSS class to `:has()` selector
 6. `content-src/styles/activity-stream.scss` — add `@import`
-7. `stylelint-rollouts.config.js` (repo root) — add the new widget's SCSS path in alphabetical order alongside the other widget entries
-8. `Base.jsx`, `CustomizeMenu.jsx`, `ContentSection.jsx` — Customize panel toggle
-9. `browser/locales/en-US/browser/newtab/newtab.ftl` — FTL strings
+7. `content-src/styles/nova/activity-stream.scss` — add `@import` (**required — without this, styles won't render in Nova mode**)
+8. `stylelint-rollouts.config.js` (repo root) — add the new widget's SCSS path in alphabetical order alongside the other widget entries
+9. `Base.jsx`, `CustomizeMenu.jsx`, `ContentSection.jsx` — Customize panel toggle
+10. `AboutPreferences.sys.mjs` — register prefs, settings, and items for `about:preferences`
+11. `browser/locales/en-US/browser/newtab/newtab.ftl` — FTL strings for new tab
+12. `browser/locales/en-US/browser/preferences/preferences.ftl` — FTL string for `about:preferences` toggle
 
 Additional files if the spec requires them:
 - `common/Actions.mjs` + `common/Reducers.sys.mjs` — only if Redux state is needed
@@ -51,7 +54,15 @@ Only stop if you hit a genuine blocker (e.g. a file doesn't exist where expected
 or the codebase structure differs from what the plan assumed). In that case,
 explain what you found and what decision is needed before continuing.
 
-### Step 4 — Follow-up
+### Step 4 — Build and verify
+
+After scaffolding, the build artifacts must be regenerated:
+
+1. `./mach newtab bundle` — compile SCSS and JS (**`./mach build faster` alone does NOT recompile SCSS**)
+2. `./mach build faster` — copy compiled artifacts to the build output
+3. Commit the build artifacts: `css/activity-stream.css`, `css/nova/activity-stream.css`, `data/content/activity-stream.bundle.js`
+
+### Step 5 — Follow-up
 
 Remind the user:
 - Add any remaining Fluent strings for context menu items and widget body labels
@@ -61,7 +72,8 @@ Then explain how to enable the widget:
 
 **Option A — `about:config`**
 
-Set both of these to `true`:
+Set **all three** of these to `true`:
+- `browser.newtabpage.activity-stream.widgets.system.enabled` (parent gate for all widgets — defaults to `false`)
 - `browser.newtabpage.activity-stream.widgets.{widgetKey}.enabled`
 - `browser.newtabpage.activity-stream.widgets.system.{widgetKey}.enabled`
 

--- a/plugins/newtab/skills/widgets-scaffold/references/notes.md
+++ b/plugins/newtab/skills/widgets-scaffold/references/notes.md
@@ -11,6 +11,49 @@ logic in `Widgets.jsx` reads prefs from the Redux store — if they aren't
 registered by the build yet, the widget won't appear even when Nimbus/trainhop
 is configured.
 
+## SCSS must be imported in BOTH stylesheets
+
+There are two activity-stream SCSS entry points:
+
+1. `content-src/styles/activity-stream.scss` — classic layout
+2. `content-src/styles/nova/activity-stream.scss` — Nova layout
+
+**You must add the `@import` to both files.** If you only add it to one,
+the widget will have zero styles in the other layout mode. Nova is the
+active layout for most users, so missing the Nova import means the widget
+renders completely unstyled.
+
+## `./mach newtab bundle` is required for SCSS changes
+
+`./mach build faster` only copies already-compiled files to the build output.
+It does **not** recompile SCSS or JS. After any SCSS or JSX change:
+
+1. Run `./mach newtab bundle` to compile
+2. Run `./mach build faster` to copy to the build output
+3. Reload `about:newtab`
+
+The compiled artifacts (`css/activity-stream.css`, `css/nova/activity-stream.css`,
+`data/content/activity-stream.bundle.js`) are checked into the repo and must be
+committed after bundling.
+
+## `widgets.system.enabled` is the parent gate
+
+The entire widgets section (customize panel, about:preferences, and the widget
+container on the new tab page) is gated by `widgets.system.enabled`, which
+defaults to `false`. Even with all per-widget prefs set correctly, nothing
+appears unless this parent gate is enabled via `about:config` or a Nimbus
+experiment.
+
+## Base.jsx has TWO CustomizeMenu renders
+
+`Base.jsx` renders `<CustomizeMenu>` in **two separate locations** (for
+different layout modes). You must add the `mayHave{Name}Widget` prop to
+**both** JSX blocks. If you only add it to one, the customize panel toggle
+silently won't appear in the other layout.
+
+Search for `mayHaveListsWidget={` in Base.jsx — you should see two matches.
+Add your new prop next to both.
+
 ## CustomizeMenu.jsx is a required passthrough
 
 `Base.jsx` passes `mayHave*Widget` props to `<CustomizeMenu>`, which forwards
@@ -24,10 +67,58 @@ Files to touch for the Customize panel toggle (all four are required):
 3. `ContentSection.jsx` — add the `switch` case and render the `moz-toggle`
 4. `browser/locales/en-US/browser/newtab/newtab.ftl` — add the toggle label string
 
-## FTL file location and string formats
+## AboutPreferences.sys.mjs registration
 
-All widget strings go in `browser/locales/en-US/browser/newtab/newtab.ftl`.
-Not the `webext-glue/locales/` path (that's a different, generated file).
+Widgets must be registered in `AboutPreferences.sys.mjs` to appear in
+`about:preferences > Home`. Three changes are needed in this file:
+
+**1. Pref definitions** (in the `preferences` array near the top):
+```js
+{
+  id: "browser.newtabpage.activity-stream.widgets.system.{widgetKey}.enabled",
+  type: "bool",
+},
+{
+  id: "browser.newtabpage.activity-stream.widgets.{widgetKey}.enabled",
+  type: "bool",
+},
+```
+
+**2. Settings** (in `_setupHomeGroup`):
+```js
+Preferences.addSetting({
+  id: "{widgetKey}Enabled",
+  pref: "browser.newtabpage.activity-stream.widgets.system.{widgetKey}.enabled",
+});
+
+Preferences.addSetting({
+  id: "{widgetKey}",
+  pref: "browser.newtabpage.activity-stream.widgets.{widgetKey}.enabled",
+  deps: ["{widgetKey}Enabled"],
+  visible: ({ {widgetKey}Enabled }) => {widgetKey}Enabled.value,
+});
+```
+
+**3. Items array** (add to the `widgets` section's `items`):
+```js
+{
+  id: "{widgetKey}",
+  l10nId: "home-prefs-{css-class}-header",
+},
+```
+
+**4. FTL string** in `browser/locales/en-US/browser/preferences/preferences.ftl`:
+```ftl
+home-prefs-{css-class}-header =
+    .label = {Display Name}
+```
+
+## FTL file locations and string formats
+
+Widget strings live in **two separate FTL files**:
+
+- `browser/locales/en-US/browser/newtab/newtab.ftl` — new tab page strings
+- `browser/locales/en-US/browser/preferences/preferences.ftl` — about:preferences strings
 
 Add a `##` group comment only at the start of the section, not at the end.
 A `##` with no messages after it is a lint error (GC04).
@@ -52,6 +143,31 @@ newtab-{css-class}-widget-menu-learn-more = Learn more
 ```ftl
 newtab-widget-menu-hide = Hide
 ```
+
+## Action types must be alphabetically sorted
+
+The action types array in `common/Actions.mjs` is alphabetically sorted, and
+there is an existing test that asserts this ordering. If you add new action
+types out of alphabetical order, that test will fail. For example,
+`WIDGETS_WORD_OF_THE_DAY_SEEN` must come before `WIDGETS_WORD_OF_THE_DAY_SET`.
+
+## Existing hideAllWidgets tests will break
+
+Adding a new `dispatch(ac.SetPref(...))` call to `hideAllWidgets()` in
+`Widgets.jsx` changes the number of `SetPref` dispatches. The existing tests
+in `test/unit/content-src/components/Widgets.test.jsx` assert the exact count.
+Update the expected count and assertion messages in these tests:
+
+- "should dispatch SetPref actions when hide button is clicked"
+- "should dispatch SetPref actions when Enter key is pressed on hide button"
+- "should dispatch SetPref actions when Space key is pressed on hide button"
+
+## Use `.jsx` extension for content-src data files
+
+Files in `content-src/` must use the `.jsx` extension, not `.js`. The ESLint
+config only treats `test/**/*.js` files as ES modules. A `.js` file in
+`content-src/` will fail with: `Parsing error: 'import' and 'export' may
+appear only with 'sourceType: module'`.
 
 ## handleUserInteraction is conditional
 
@@ -108,7 +224,7 @@ const mayHave{ComponentName}Widget =
 
 Also add `{widgetKey}Enabled: prefs["widgets.{widgetKey}.enabled"]` to the
 `enabledWidgets` object in `Base.jsx`, and pass `mayHave{ComponentName}Widget`
-as a prop to `<CustomizeMenu>`.
+as a prop to **both** `<CustomizeMenu>` renders.
 
 **Widget component itself** — only needed when the component has its own
 `return null` guard (i.e. special enable conditions from Q9). Read the trainhop


### PR DESCRIPTION
I created a "Word of the Day" widget to test out the new Claude skill and see what it's like to make a widget. During this process, I had to make fixes to the widget that could have been handled by the widget skill. The changes in this PR should help improve the skill.

 SKILL.md:
  - Added content-src/styles/nova/activity-stream.scss as a required file (item 7)
  - Added AboutPreferences.sys.mjs as a required file (item 10)
  - Added preferences.ftl as a required file (item 12)
  - Added new Step 4 (Build and verify) with ./mach newtab bundle + artifact commit instructions
  - Updated enable instructions to include the widgets.system.enabled parent gate

  notes.md — added 6 new sections:
  - SCSS must be imported in BOTH stylesheets — the Nova import was the #1 blocker
  - ./mach newtab bundle is required — build faster doesn't recompile SCSS
  - widgets.system.enabled is the parent gate — defaults to false, blocks everything
  - Base.jsx has TWO CustomizeMenu renders — must add props to both
  - AboutPreferences.sys.mjs registration — full pattern with 4 sub-steps
  - Action types must be alphabetically sorted — existing test enforces this
  - Existing hideAllWidgets tests will break — expected dispatch count changes
  - Use .jsx extension for content-src data files — .js fails ESLint parsing
