### PR TITLE
Document FeatureManifest declaration step in New Tab widget scaffold skill

### DIFF
--- a/plugins/newtab/skills/widgets-scaffold/SKILL.md
+++ b/plugins/newtab/skills/widgets-scaffold/SKILL.md
@@ -40,6 +40,7 @@ Files touched by every widget:
 11. `AboutPreferences.sys.mjs` — register prefs, settings, and items in the Home group (`about:preferences#home`), set up in `_setupHomeGroup`
 12. `browser/locales/en-US/browser/newtab/newtab.ftl` — FTL strings for new tab
 13. `browser/locales/en-US/browser/preferences/preferences.ftl` — FTL string for `about:preferences` toggle
+14. `toolkit/components/nimbus/FeatureManifest.yaml` — declare `{widgetKey}Enabled` under the `newtabWidgets` feature so Nimbus surfaces the variable (without this, `prefs.widgetsConfig?.{widgetKey}Enabled` is always `undefined` and only the system-pref / trainhop paths work)
 
 Additional files if the spec requires them:
 - `common/Actions.mjs` + `common/Reducers.sys.mjs` — only if Redux state is needed

--- a/plugins/newtab/skills/widgets-scaffold/references/notes.md
+++ b/plugins/newtab/skills/widgets-scaffold/references/notes.md
@@ -194,6 +194,40 @@ Any handler that dispatches two or more actions must wrap them in `batch()`
 to avoid intermediate renders. This includes `handleHide`, user event handlers,
 and any action that pairs a state change with a telemetry dispatch.
 
+## Nimbus FeatureManifest declaration
+
+The variable read via `prefs.widgetsConfig?.{widgetKey}Enabled` (in
+`Widgets.jsx` and `Base.jsx`) is surfaced through the `newtabWidgets` feature
+in `toolkit/components/nimbus/FeatureManifest.yaml`. Declare it there
+alongside the existing entries (`enabled`, `listsEnabled`, `timerEnabled`,
+`listsBadgeEnabled`, `listsBadgeLabel`):
+
+```yaml
+newtabWidgets:
+  variables:
+    {widgetKey}Enabled:
+      type: boolean
+      description: >-
+        Enable {Display Name} widget
+```
+
+Without this declaration, Nimbus has no schema for the variable, so
+`prefs.widgetsConfig?.{widgetKey}Enabled` always reads as `undefined`. The
+system-pref and trainhop paths continue to work, which makes the gap easy to
+miss in local testing — the widget appears to enable correctly via
+`about:config` and `newtabTrainhop`, but every real Nimbus rollout silently
+no-ops.
+
+Only the `newtabWidgets` feature path needs this. The trainhop path
+(`prefs.trainhopConfig?.widgets?.{widgetKey}Enabled`) consumes the
+`newtabTrainhop` feature's payload as opaque JSON, so individual keys inside
+it do not need separate declarations.
+
+`FeatureManifest.yaml` lives outside `browser/extensions/newtab/` and rides
+the trains — it is not trainhoppable. The variable must land in a Firefox
+release before any code reading it via the Nimbus feature path can rely on
+it; on older channels it will be `undefined`.
+
 ## Nimbus trainhop naming convention
 
 The trainhop key follows camelCase + "Enabled" suffix:


### PR DESCRIPTION
## Summary

Adding `{widgetKey}Enabled` to the `newtabWidgets` feature in `FeatureManifest.yaml` is required for the Nimbus path to work. Without it, `prefs.widgetsConfig?.{widgetKey}Enabled` is always `undefined` and the gap is easy to miss in local testing because system-pref and trainhop paths continue working.

Follow-up to setting up the Clocks widget recently (https://bugzilla.mozilla.org/show_bug.cgi?id=2034279) where this was missed and only caught in review when a reviewer explicitly asked about Nimbus. 
