### PR TITLE
Add three review skills and refresh ipprotection-review

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,6 +12,14 @@
     {
       "name": "ipprotection",
       "source": "./plugins/ipprotection"
+    },
+    {
+      "name": "desktoptheme",
+      "source": "./plugins/desktoptheme"
+    },
+    {
+      "name": "accessibilityfrontend",
+      "source": "./plugins/accessibilityfrontend"
     }
   ]
 }

--- a/plugins/accessibilityfrontend/.claude-plugin/plugin.json
+++ b/plugins/accessibilityfrontend/.claude-plugin/plugin.json
@@ -1,0 +1,5 @@
+{
+  "name": "accessibilityfrontend",
+  "description": "Skills and tools for Firefox accessibility frontend development",
+  "version": "1.0.0"
+}

--- a/plugins/accessibilityfrontend/README.md
+++ b/plugins/accessibilityfrontend/README.md
@@ -1,0 +1,11 @@
+# Firefox Accessibility Frontend Plugin
+
+Skills and tools for Firefox accessibility frontend development.
+
+## Skills
+
+### `accessibility-frontend-review`
+
+Review guidance for Firefox accessibility frontend patches, covering High Contrast Mode, screen reader exposure, keyboard navigation, design tokens, and Fluent localization.
+
+Use this skill when reviewing patches that change interactive UI, semantics, focus management, color tokens, or strings in `browser/`, `toolkit/`, or `accessible/`. See [`skills/accessibility-frontend-review/SKILL.md`](skills/accessibility-frontend-review/SKILL.md) for details.

--- a/plugins/accessibilityfrontend/skills/accessibility-frontend-review/SKILL.md
+++ b/plugins/accessibilityfrontend/skills/accessibility-frontend-review/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: accessibility-frontend-review
+description: Review guidance for Firefox accessibility-frontend patches, covering High Contrast Mode, screen reader exposure, keyboard navigation, design tokens, and Fluent localization.
+---
+
+# Accessibility Frontend Review Skill
+
+## Standing Conventions
+
+### High Contrast Mode (HCM) and `forced-colors`
+- Whenever a patch sets a background, border, or foreground color, the same selector must produce a sensible result under `@media (forced-colors)`. Use CSS system colors (`ButtonText`, `ButtonFace`, `SelectedItem`, `SelectedItemText`, `Canvas`, `CanvasText`, `GrayText`) — never hex/RGB values that survive into HCM.
+- Pair colors correctly: `ButtonText`/`ButtonFace` for default controls, `SelectedItem`/`SelectedItemText` for hover and active interactive states, `Canvas`/`CanvasText` for static surfaces and text. Never mix a custom foreground with a system background.
+- When changing the background of an interactive element for hover/active/selected, also update its foreground and add a 1px solid border in the matching system color. Background-only changes are invisible in HCM.
+- Drop opacity, transparency, gradients, drop shadows, and `background-image` decorations under `forced-colors`; they either disappear or break contrast.
+- Prefer overriding design-token values inside a `@media (forced-colors)` block at `:root`, then consume the same token name throughout. Avoid duplicating selector blocks just to swap colors.
+- Distinguish `prefers-contrast` (Increase Contrast — keep the regular palette, add borders, optionally tweak readability) from `forced-colors` (HCM — full system-color palette). Don't lump them together.
+
+### Design Tokens
+- Use design-system tokens from `tokens-shared.css` / `tokens-brand.css` — never hardcoded colors, opacities, or font sizes — and pick tokens that match the semantic role (text tokens for text, button tokens for buttons, ghost-button tokens for ghost buttons, link tokens for links).
+- Keep token families consistent within a state: if the border uses `--button-border-color-primary-hover`, the background and text must use the matching `-primary-hover` tokens.
+- `--font-size-xsmall` is reserved for legal/sponsored microcopy. Do not introduce new uses; flag any new use in a review.
+- Use `--text-color` for primary text and `--text-color-deemphasized` only where the design calls for it; verify both resolve correctly in HCM.
+
+### Screen Reader & Semantics
+- Every interactive element needs an accessible name. For icon-only buttons, set a non-empty label (Fluent `.aria-label`, `title`, or visible text). Verify with NVDA, VoiceOver, and the Accessibility panel — not just by reading code.
+- Expose state changes (pressed, selected, expanded, muted, playing) through ARIA or native semantics; don't rely on visual-only cues. Toggle buttons that change icon/state must also change their accessible name or use `aria-pressed`.
+- Prefer native semantic markup (`<h1>`–`<h6>`, `<section>`, `<fieldset>`/`<legend>`, lists) over `role=` patches. Avoid `role="group"` on `<ul>` — it suppresses list semantics.
+- Use `aria-labelledby`/`aria-describedby` (or `aria-description` where supported) to associate group headings, helper text, and badges with the focusable control. Set them on the focusable element or its enclosing group, not on a non-focusable sibling.
+- Don't rely on transient announcements for content the user must be able to re-read; prefer durable DOM associations. For one-shot announcements (e.g. urlbar tips), use the existing `A11yUtils.announce` framework rather than ad-hoc live regions.
+- For ARIA widgets that diverge from the spec (mixed list/grid, multi-cell rows, custom keyboard shortcuts), document the keyboard model and confirm screen-reader behavior across NVDA, VoiceOver, and Orca.
+
+### Keyboard Navigation & Focus
+- Every interactive control must be reachable by Tab/arrow keys per its widget pattern. Toolbar buttons should integrate with `ToolbarKeyboardNavigator` (place after the appropriate `<toolbartabstop>`); avoid bare `tabindex` workarounds without justification.
+- `Space` and `Enter` should both activate buttons/menubuttons consistently across platforms; `Shift+F10` and the context-menu key should open context menus where applicable.
+- After a destructive or transformative action (clear, dismiss, submit), focus must land somewhere predictable — typically the originating control or the next logical target — never lost to `<body>`.
+- Modal-style dialogs that block dismissal via `Esc` or backdrop click must move focus into the dialog, set `aria-modal="true"`, and visually convey modality.
+- Don't intercept clicks inside shadow DOM and re-dispatch on the host without considering accessibility checks; this breaks `mustHaveAccessibleRule` and assistive-tech targeting.
+
+### Localization (Fluent)
+- New user-visible strings go in `.ftl` files with lowercase-hyphenated message IDs. When meaning changes materially, mint a new ID rather than editing in place.
+- Pass `data-l10n-args` for variables; never concatenate translated fragments in JS. Use `document.l10n.setAttributes` for runtime-set strings.
+- Treat the localized output as opaque: don't substring, slice, or compare against literal translated text in tests. Assert on `data-l10n-id`/`data-l10n-args` instead.
+- Patches touching `.ftl` files require review from `#fluent-reviewers`; the Herald hook adds them automatically — don't remove them.
+
+### Testing & A11y Checks
+- New focusable widgets must pass mochitest `AccessibilityUtils` checks. When `synthesizeMouseAtCenter` triggers `mustHaveAccessibleRule` failures because of shadow-DOM event re-dispatch, prefer fixing the component's event handling; only use `setEnv` to suppress the rule with a comment explaining why.
+- Run patches against pseudolocales (`intl.l10n.pseudo=bidi` and `=accented`) to catch hardcoded strings, truncation, and RTL issues before requesting review.
+- For HCM coverage, test on at least one Windows 11 dark theme (e.g. Night Sky) and one light theme (e.g. Desert), plus macOS Increase Contrast where relevant. Screenshots in the review request speed up sign-off considerably.
+
+## Common Pitfalls
+
+- Setting `background-color` for a hover/active/selected state without also updating `color` and `border-color` — invisible in HCM.
+- Using `opacity` to dim disabled or de-emphasized UI; HCM users get either invisible text or unreadable contrast. Use `GrayText` or explicit color tokens.
+- Hardcoding hex/RGB colors inside a `forced-colors` block instead of using design tokens or system colors.
+- Forgetting `alt` on `<img>` (use `alt=""` for purely decorative images, otherwise a real description).
+- Adding a `title` whose value is an l10n ID string (e.g. `title="my-button-id"`), exposing the raw identifier to users.
+- Removing `Mozilla-style label` association by replacing semantic elements (e.g. `<h4>`) with generic XUL containers and losing heading structure.
+- Toggle controls whose label/icon updates visually but whose accessible name stays static (e.g. "Add to taskbar" remaining after the action succeeds).
+- Box-shadow focus rings; they vanish in Windows HCM. Use `outline` or `border` with `CanvasText`/`SelectedItem`.
+- Live regions or announcements that fire on initial render, spamming screen readers with content the user can already discover statically.
+- Long, instructional `aria-label`s on group containers ("Press Tab to move… Press Down to continue"). Users hear them on every entry; keep group labels short and document keyboard shortcuts in SuMo.
+- Putting localizable text inside JS string concatenation or computing it from multiple FTL messages.
+
+## File-Glob Guidance
+
+- `browser/themes/shared/**/*.css`, `toolkit/themes/shared/**/*.css`: Verify every color rule has an HCM story. Prefer overriding tokens at `:root` inside `@media (forced-colors)` over duplicating selectors. Watch for `box-shadow` used as focus indication.
+- `browser/components/**/*.css`, `browser/extensions/newtab/**/*.scss`: Same HCM rules apply; also check that `--font-size-xsmall` is not introduced for new copy and that hover/active/selected states all swap to `SelectedItem`/`SelectedItemText` pairs.
+- `toolkit/content/widgets/moz-*/*.mjs`: Reusable components must expose `aria-label`, `aria-description`, and selected/checked state correctly. Verify Storybook stories match shipped behavior. Don't stop-and-redispatch click events on the host without preserving accessibility-tree targeting.
+- `**/*.ftl`, `browser/locales/en-US/**`: Mint new IDs on meaning change; require `#fluent-reviewers`. Keep IDs lowercase-hyphenated. Prefer attribute-style messages (`.label`, `.tooltiptext`) over multiple flat IDs.
+- `accessible/**`: Changes to role mapping, name computation, or relation handling can break every consumer; require explicit cross-platform screen-reader verification (NVDA, VoiceOver, Orca).
+- `browser/components/preferences/**`: Changes to settings UI must preserve live-region behavior for warnings/alerts that appear on toggle. Telemetry probe shape changes need a migration note.
+- `**/test/**/*.js`: Tests should assert `data-l10n-id`/`data-l10n-args` and ARIA attributes, not localized strings. When suppressing an a11y check, leave a comment linking to the underlying issue.
+
+## Review Checklist
+
+1. Every interactive control has a non-empty accessible name; verify with the Accessibility panel or a screen reader, not by reading source.
+2. Every color rule resolves correctly under `@media (forced-colors)` — system colors only, paired correctly, with a visible border on interactive surfaces.
+3. Hover, active, focus, selected, and disabled states are all visually distinct in default, Increase Contrast, and HCM.
+4. No hardcoded colors, font sizes, or opacities; design tokens are used and chosen by semantic role.
+5. Focus is reachable via the documented keyboard pattern (Tab, arrows, Space/Enter, Esc) and lands somewhere predictable after every action.
+6. State changes (toggled, expanded, selected, muted) are exposed to ARIA, and labels update when meaning changes.
+7. Modal dialogs that block soft-dismiss have `aria-modal`, focus management, and a visible modal affordance.
+8. New `.ftl` strings have stable IDs, use `data-l10n-args` for variables, and the patch carries `#fluent-reviewers`.
+9. Tests assert on l10n IDs and ARIA attributes, not on translated strings; a11y-checks are not silenced without a comment.
+10. The patch has been spot-checked against a pseudolocale and against at least one HCM theme; screenshots accompany non-trivial visual changes.
+11. New live regions or announcements are necessary, non-redundant, and don't fire on every render.
+12. Reusable component changes ship with Storybook coverage and have been verified across NVDA, VoiceOver, and (where feasible) Orca.
+
+## House style references
+
+- [CSS Guidelines](https://firefox-source-docs.mozilla.org/code-quality/coding-style/css_guidelines.html)
+- [SVG Guidelines](https://firefox-source-docs.mozilla.org/code-quality/coding-style/svg_guidelines.html)
+- [RTL Guidelines](https://firefox-source-docs.mozilla.org/code-quality/coding-style/rtl_guidelines.html)
+- [JavaScript Coding Style](https://firefox-source-docs.mozilla.org/code-quality/coding-style/coding_style_js.html)
+- [C++ Coding Style](https://firefox-source-docs.mozilla.org/code-quality/coding-style/coding_style_cpp.html)
+- [Using C++ in Firefox Code](https://firefox-source-docs.mozilla.org/code-quality/coding-style/using_cxx_in_firefox_code.html)
+- [Fluent Localization Tutorial](https://firefox-source-docs.mozilla.org/l10n/fluent/tutorial.html)

--- a/plugins/desktoptheme/.claude-plugin/plugin.json
+++ b/plugins/desktoptheme/.claude-plugin/plugin.json
@@ -1,0 +1,5 @@
+{
+  "name": "desktoptheme",
+  "description": "Skills and tools for Firefox desktop theme and shared CSS development",
+  "version": "1.0.0"
+}

--- a/plugins/desktoptheme/README.md
+++ b/plugins/desktoptheme/README.md
@@ -1,0 +1,11 @@
+# Firefox Desktop Theme Plugin
+
+Skills and tools for Firefox desktop theme and shared CSS development.
+
+## Skills
+
+### `desktop-theme-review`
+
+Review guidance for Firefox desktop theme patches, covering design tokens, logical properties, High Contrast Mode, SVG conventions, and Fluent localization across `browser/themes/` and `toolkit/themes/`.
+
+Use this skill when reviewing changes under `browser/themes/**`, `toolkit/themes/**`, or shared design-system tokens. See [`skills/desktop-theme-review/SKILL.md`](skills/desktop-theme-review/SKILL.md) for details.

--- a/plugins/desktoptheme/skills/desktop-theme-review/SKILL.md
+++ b/plugins/desktoptheme/skills/desktop-theme-review/SKILL.md
@@ -1,0 +1,106 @@
+---
+name: desktop-theme-review
+description: Conventions for reviewing CSS, SVG, and front-end theme patches in Firefox's desktop chrome and shared toolkit theming layers.
+---
+
+## Standing Conventions
+
+### Design tokens & variables
+1. Use design tokens (space, size, icon-size, font-size, font-weight, border-radius, color, opacity, focus-outline) instead of literal px/rem/hex values. Tokens carry semantic meaning and adapt to dark mode, HCM, and Nova; raw values do not.
+2. Do not use base/primitive tokens (`--color-gray-50`, `--color-violet-70`, etc.) directly in component CSS. Define a semantic local variable that aliases the base token, or use the appropriate semantic token (`--text-color`, `--background-color-box`, `--border-color`). The stylelint `use-design-tokens` rule enforces this.
+3. Edit token values in the JSON sources under `toolkit/themes/shared/design-system/src/tokens/` and run `./mach buildtokens`; never hand-edit the generated `dist/tokens-*.css` files.
+4. New module-wide custom properties belong in the relevant tokens JSON or a component-scoped `.css` file, not scattered across consumer stylesheets. If a value is used once, inline it instead of inventing a variable.
+
+### Localization & RTL
+5. Use logical properties (`margin-inline-*`, `padding-inline-*`, `inset-inline-*`, `border-inline-*`, `border-start-start-radius`, etc.) rather than `left`/`right`. For background/transform-based assets that need mirroring, use `:dir(rtl)` (or `:-moz-locale-dir(rtl)` in XUL) to override or supply a mirrored asset. Test RTL via `intl.l10n.pseudo = bidi`.
+6. New user-visible strings live in Fluent (`.ftl`); changing the meaning of a string requires a new Fluent ID. Fluent review is required for `.ftl` changes; reusable components must work with `data-l10n-id` and `data-l10n-attrs`.
+
+### Accessibility & High Contrast Mode
+7. Do not rely on `box-shadow` for focus rings or borders that must remain visible — they are stripped in HCM. Use `outline` (with `--focus-outline`/`--focus-outline-offset`) or `border` instead.
+8. When overriding colors, override foreground and background as a pair, and prefer the existing `--button-*`, `--text-color*`, `--border-color*` semantic tokens over hand-rolled `prefers-contrast`/`forced-colors` blocks — the tokens already handle those modes. If you must media-query, prefer `@media (forced-colors)` for Windows HCM and `@media (prefers-contrast)` for the broader case; do not duplicate rules across both.
+9. Avoid font sizes below 12px in chrome; macOS already shrinks `font: menu` to 11px and going smaller hits accessibility limits. For deemphasized text use `--text-color-deemphasized` (and `var(--font-size-small)` only when truly needed), not hardcoded grays or 11px values.
+
+### Selectors & specificity
+10. Prefer the child combinator (`>`) over descendant selectors when the structure is known, and prefer class selectors over element selectors. Use `:where()` to keep specificity low when adding rules that should be easy to override. Avoid `!important` unless overriding another `!important` declaration; document why with a comment when you must.
+11. Avoid `:has()` in selectors that match frequently or in tab-strip/urlbar/menu hot paths — it is expensive. Restructure markup to expose an attribute or class instead.
+12. Boolean attributes follow HTML semantics (`disabled`, `hidden`, `checked`, `open`): match presence (`[disabled]`), not `[disabled="true"]`. Do not write `="true"` in selectors.
+
+### CSS structure
+13. Use nesting to group related rules under a common selector, but cap nesting depth (stylelint enforces this) and unnest rules whose selectors don't actually share the parent's scope. Don't nest just to deduplicate a selector fragment if the result is harder to read.
+14. Use `light-dark()` for two-value color pairs instead of duplicating rules under `prefers-color-scheme` media queries. `light-dark()` only works for color values; for non-color light/dark variants, factor into a custom property.
+15. Omit unit on `0` (`margin: 0`, not `0px`) — except inside `calc()` where `0px` is required for the calculation to type-check.
+
+### SVG
+16. New icons follow the `{name}-{variant}-{size}.svg` convention; omit the size suffix for the default 16px icon, and use `-12` / `-20` / etc. for explicit sizes. Icons must be square at the documented size; non-square assets get bounced back to UX. Place shared icons under `toolkit/themes/shared/icons/` (or `browser/themes/shared/icons/` for browser-only); feature-specific assets stay in the feature folder.
+17. SVGs must include the MPL license header, use 2-space indentation with one element per line, and use `fill="context-fill"` (and `context-fill-opacity`, `context-stroke` as needed) so callers can recolor via `-moz-context-properties`. Strip Figma metadata (`data-figma-*`), unused `<defs>`, no-op `clip-path`s, editor namespaces, and useless ids before landing. Run new SVGs through svgomg or equivalent.
+
+### Testing & process
+18. Patches touching `.ftl` need `#fluent-reviewers`; patches touching shared CSS/icons need `#desktop-theme-reviewers`; reusable widgets under `toolkit/content/widgets/` need `#reusable-components-reviewers`. Don't request review across the world — the Herald hooks pick the right groups from path globs.
+19. Run `./mach lint --fix --outgoing` (Prettier + stylelint) before submitting. If you add a new `.css` file or icon, also confirm `browser_all_files_referenced.js` and `browser_parsable_css.js` still pass — unused custom properties and dangling references fail those tests. New reusable components must be registered in `toolkit/content/customElements.js` to avoid the all-files-referenced failure.
+
+## Active Campaigns (transient)
+
+- **Nova redesign tokens & overrides.** A second token layer (`*.nova.tokens.json`, `browser.nova.enabled` / `browser.theme.native-theme` prefs, `--ai-*` and Smart Window variables) is being layered on top of existing tokens. New CSS should keep Nova-specific overrides scoped (`@media -moz-pref("browser.nova.enabled")` or `:root[lwtheme]` etc.) and avoid hand-rolling values that the Nova token import will eventually supply. *Context: likely to fade once Nova ships and the override layer is collapsed into the base tokens.*
+- **Settings Redesign (SRD) — config-based prefs.** Settings panes are being converted from hand-written XUL to config-driven `setting-group` / `setting-pane` / `setting-control` rendered from `Preferences.addSetting(...)` configs. New settings should be added via config, not new XUL; old XUL remains gated on `browser.settings-redesign.enabled` until the migration is complete. *Context: likely to fade once all panes are converted and the legacy XUL paths are removed.*
+- **`--in-content-*` removal.** Legacy `--in-content-button-*`, `--in-content-item-*`, `--in-content-border-color`, `--in-content-page-background`, etc. are being replaced with semantic tokens (`--button-*`, `--background-color-*`, `--border-color`, `--color-accent-primary-selected`). Don't introduce new uses of `--in-content-*` variables; replace them when you touch nearby code. *Context: likely to fade once the variable set is fully removed from `toolkit/themes/shared/in-content/common-shared.css`.*
+
+## Common Pitfalls
+
+- Using `--toolbar-bgcolor` (which can be transparent and is meant to layer over the toolbox) as a flat opaque background.
+- Using `--arrowpanel-*` colors outside `:-moz-lwtheme` contexts — they are intended for webextension-themed surfaces.
+- Hardcoding `font-weight: 600`/`590`/`bold` instead of `var(--font-weight-bold)` (now `--font-weight-semibold`) or `--heading-font-weight`.
+- Forgetting that `prefers-contrast` matches on macOS Increased Contrast as well — rules guarded by it must work on macOS, not just Windows HCM. Use `(forced-colors)` when the rule is genuinely Windows-HCM-specific.
+- Adding `transition` / `animation` without a `@media (prefers-reduced-motion: no-preference)` guard for movement-based effects.
+- Using a fixed `px` `font-size` in chrome — chrome inherits the OS menu font and px values break OS-density and zoom expectations. Use `em`, `1lh`, or font-size tokens.
+- Adding `display: none` to elements that should remain in the a11y tree; use `-moz-subtree-hidden-only-visually` or `visibility: hidden` when the tree must be preserved.
+- Treating `:active` and `[selected]`/`[open]` as the same state — they are visually distinct and serve different purposes; don't conflate them in HCM rules.
+- Setting widths/positions in `px` for elements whose size depends on text (tabs, menu items, urlbar): use `em` or `lh` so they scale with system font size and per-platform font defaults.
+- Fighting `moz-button` styling with `::part()` overrides instead of using the documented attributes (`type`, `size`, `iconSrc`, theme tokens). `::part` is fragile across redesigns.
+
+## File-Glob Guidance
+
+### `browser/themes/shared/**` and `toolkit/themes/shared/**`
+- Keep platform-specific tweaks in `browser/themes/{linux,osx,windows}/` (or via `@media (-moz-platform: ...)`) — never inline platform hacks in shared files.
+- New shared variables must be referenced from at least two consumers, otherwise inline the value.
+
+### `browser/themes/shared/tabbrowser/**`
+- The tab strip is performance-sensitive: avoid `:has()`, avoid setting custom properties on every tab, and prefer setting state attributes on `#tabbrowser-tabs` over recomputing per-tab. Mind both `[orient="horizontal"]` and `[orient="vertical"][expanded]` modes plus pinned/unpinned and split-view variants when adding rules. Tab tokens live in `tab.tokens.json`.
+
+### `browser/themes/shared/urlbar*/**`
+- Treat the urlbar as its own size domain: it has a platform-specific font scale, its own `--urlbar-*` and `--urlbarview-*` tokens, and its own border-radius scheme (with a separate inner radius for the view). Don't reach for global space tokens without confirming they produce consistent spacing across platforms; prefer urlbar-scoped variables.
+
+### `browser/themes/addons/**` (built-in themes)
+- Express theme colors via the `manifest.json` `colors` block whenever possible; only reach into `*.css` for selectors and effects that the manifest cannot express. Don't override design tokens from a theme stylesheet — use the manifest's color keys so non-built-in themes behave consistently.
+
+### `toolkit/themes/shared/design-system/**`
+- This directory generates code; only `src/tokens/**.json` and `config/tokens-config.js` are hand-edited. Always rebuild via `./mach buildtokens` and commit the regenerated `dist/` output in the same patch.
+
+### `toolkit/content/widgets/moz-*/**` (reusable components)
+- Reusable components must work without a wrapping page context: they need a Storybook story, default-export class, and tokens/CSS variables for any color/spacing/sizing knob a consumer might tweak. Don't hardcode chrome-only or in-content-only assumptions; use semantic tokens that resolve correctly in both. (campaign) When adding properties, also expose them as Storybook controls.
+
+### `*.svg` under any theme directory
+- See standing rule 17. Confirm the asset renders correctly in light, dark, and high-contrast modes before landing.
+
+## Review Checklist
+
+- [ ] Are all colors, spaces, sizes, font-sizes, font-weights, and radii expressed via design tokens (or feature-scoped variables aliasing tokens)?
+- [ ] Logical properties used everywhere; RTL spot-checked with `intl.l10n.pseudo = bidi`?
+- [ ] HCM behavior verified — no reliance on `box-shadow` for visible borders/focus, foreground+background overridden as pairs, `forced-colors` vs `prefers-contrast` used appropriately?
+- [ ] New strings have new Fluent IDs; meaning changes get fresh IDs; `#fluent-reviewers` requested for `.ftl` edits?
+- [ ] Selector specificity is low — child combinator preferred, no `!important` without justification, no `:has()` in hot paths?
+- [ ] SVGs follow naming/size conventions, use `context-fill`, MPL header present, Figma metadata stripped?
+- [ ] Boolean attributes treated as presence-only (`[disabled]`, not `[disabled="true"]`)?
+- [ ] `transition`/`animation` guarded by `prefers-reduced-motion: no-preference` when movement is involved?
+- [ ] `./mach lint --outgoing` clean, `browser_all_files_referenced.js` and `browser_parsable_css.js` still passing?
+- [ ] If touching tokens JSON, was `./mach buildtokens` run and the generated CSS committed?
+- [ ] If touching reusable components, are Storybook stories, tests, and `customElements.js` registration updated?
+- [ ] **(campaign)** If adding/altering a setting, is it expressed via `Preferences.addSetting` + setting-group config, not new XUL?
+- [ ] **(campaign)** Nova-specific overrides scoped behind `@media -moz-pref("browser.nova.enabled")` (or equivalent) rather than mutating base tokens?
+
+## House style references
+
+- [CSS Guidelines](https://firefox-source-docs.mozilla.org/code-quality/coding-style/css_guidelines.html)
+- [SVG Guidelines](https://firefox-source-docs.mozilla.org/code-quality/coding-style/svg_guidelines.html)
+- [RTL Guidelines](https://firefox-source-docs.mozilla.org/code-quality/coding-style/rtl_guidelines.html)
+- [JavaScript Coding Style](https://firefox-source-docs.mozilla.org/code-quality/coding-style/coding_style_js.html)
+- [Fluent for Firefox Developers](https://firefox-source-docs.mozilla.org/l10n/fluent/tutorial.html)

--- a/plugins/ipprotection/skills/ipprotection-review/SKILL.md
+++ b/plugins/ipprotection/skills/ipprotection-review/SKILL.md
@@ -1,103 +1,93 @@
 ---
 name: ipprotection-review
-description: Durable review guidance for Firefox's built-in IP Protection (VPN) module, covering panel UI, proxy/channel filtering, authentication, telemetry, and localization.
+description: Conventions for reviewing patches in browser/components/ipprotection and toolkit/components/ipprotection — covering Lit-based panel components, the IPPService state machine, Fluent strings, telemetry, and proxy/channel filtering.
 ---
 
-# Module Scope
+## Standing Conventions
 
-- Paths: `browser/components/ipprotection/**/*`, `toolkit/components/ipprotection/**/*`
-- Bugzilla components: Firefox::IP Protection
+### Architecture & state flow
+- Treat `IPProtectionService` / `IPPProxyManager` as the single source of truth for VPN state; UI components must react to dispatched events (`IPPProxyManager:StateChanged`, `IPProtection:Init`, `UsageChanged`, etc.) rather than poll or duplicate state. Keeps state transitions auditable and prevents stale UI.
+- Push state mutations through `IPProtectionPanel.setState` (which batches and gates on panel visibility); content components must not mutate `this.state` directly. Avoids divergent renders across windows and keeps content elements declarative.
+- Per-window UI (toolbar button, panel, alerts) is created by an `EveryWindow`-style manager; store window references as `Cu.getWeakReference(window)` and expose getters (e.g. `gBrowser`) instead of holding strong refs. Prevents window leaks and matches the project's existing pattern.
+- Helper classes (`IPP*Helper`, `IPP*Manager`) own one concern (enrollment, autostart, onboarding flags, alerts, …) and register/unregister observers in matching `init`/`uninit` pairs. New cross-cutting behaviour belongs in a new helper, not in the service or the panel.
 
-# Core Reviewers
+### Lit components
+- Components live under `content/` as `.mjs` and are pure: props in via attributes/properties, state changes out via bubbling `composed: true` `CustomEvent`s with `IPProtection:*` names. Privileged modules (Services, ChromeUtils, FxAccounts, prefs) must not be imported into content files.
+- Use the project's `MozLitElement` query decorators to expose internal nodes (`#myEl`); avoid ad-hoc `shadowRoot.querySelector` from outside the component, and only expose nodes the panel actually needs.
+- Slot content from `IPProtectionPanel` / `ipprotection-content` rather than hardcoding child markup inside generic wrappers (e.g. status box, message bar). Style the slotted element with `::slotted()` rather than via the host's own classes.
+- Constants shared across components (URLs, max bandwidth, country→flag maps, event names, threshold buckets) live in `content/ipprotection-constants.mjs`. Don't redefine them per component.
+- Prefer design tokens (`--space-*`, `--font-size-*`, `--icon-color`, `--border-color-card`, `--color-*`) over hardcoded px/hex values; reach for `light-dark()` or existing themed variables before adding a new one. Hardcoded sizes/colors are a review blocker except where a token genuinely doesn't exist (note it and file follow-up).
 
-- Owner: fchasen
-- Peers: kpatenio, rking, niklas
+### Localization & accessibility
+- Every new user-visible string is a Fluent message in `browser/locales/en-US/browser/ipProtection.ftl`, set via `data-l10n-id` / `data-l10n-args` or `document.l10n.setAttributes`. Hardcoded English in components, dialogs, or alerts is a blocker.
+- Fluent IDs are lowercase-with-dashes, hardcoded as full strings (no string concatenation to build IDs). Reuse over invent — when meaning changes, mint a new ID rather than mutating an existing one.
+- For dynamic numeric content (bandwidth, counts), pass values as `data-l10n-args` and let the message handle plural selectors and `NUMBER`/`DATETIME` formatting. Never assemble numbers + units in JS.
+- All toolbar buttons and panel buttons need a tooltiptext or aria-label; XUL `toolbarbutton` uses `.tooltiptext`, HTML/`moz-button` uses `aria-label` or the button's label slot. Verify keyboard navigation (Tab, Shift+Tab, Enter, Space, Arrow keys) and screen reader output before approving UI patches.
+- Use logical CSS properties (`margin-inline-*`, `padding-inline-*`, `inset-inline-*`, `border-inline-*`) and `text-align: match-parent` over physical left/right. SVG icons that imply directionality must be mirrored via `:dir(rtl)` or a separate `-rtl` asset; symmetric icons must not be flipped.
 
-# Standing Conventions
+### Prefs, telemetry & data
+- Prefs live under `browser.ipProtection.*` (camelCase tail), are registered in `firefox.js`, and are documented in `browser/components/ipprotection/docs/`. Use `XPCOMUtils.defineLazyPreferenceGetter` for hot-path reads and `Services.prefs.addObserver` (cleaned up in `uninit`) for change reactions. Don't read prefs from content components — pipe values through panel state.
+- Glean metrics live in `metrics.yaml`; new events require a description, the relevant notification emails (including `vpn-telemetry@mozilla.com` for VPN-scoped events), and either a corresponding browser test or an explicit `testing-exception-*` tag with rationale.
+- Treat the entitlement and proxy pass as authoritative for bandwidth — derive `max`, `remaining`, and `reset` from the proxy manager's `usageInfo`, never re-implement them from a constant. The cached startup state must be invalidated when sign-in state, entitlement, or `bandwidthUsage` changes.
 
-## State & Data Flow
-- Route state mutations through `IPProtectionPanel.setState({...})` rather than having child components mutate panel state directly; keep `IPProtectionPanel` as the single source of truth for panel state, and prefer batched `setState` calls over property-by-property assignment.
-- Prefer communicating across components via `CustomEvent` dispatched from the shared root and consumed by the panel/manager, rather than sharing state between sibling files. Use `Services.obs` observers (e.g. `perm-changed`) instead of calling into internal callbacks when the platform already emits the signal.
-- When adding/removing `addObserver`/`removeObserver` or `addEventListener` pairs, bind the handler once in the constructor (or use `handleEvent`) — do not pass `.bind(this)` at registration time, since the two bindings won't match on removal.
+### Testing
+- Use `add_setup` / `registerCleanupFunction` and prefer `SpecialPowers.pushPrefEnv` over manual pref save/restore. Reset the panel via the shared `openPanel` / `closePanel` helpers in `tests/browser/head.js` rather than building bespoke setup.
+- Stub external surfaces (`fxAccounts`, `openWebLinkIn`, `GuardianClient` HTTP, `fetchProxyPass`, network observers) with sinon and restore them on cleanup. Don't hit the real network or the real support site in tests.
+- Assertions on l10n should compare `getAttributes(el)` to expected `{ id, args }`, not against rendered text. For visibility/state changes that are async, use `BrowserTestUtils.waitForCondition` rather than fixed timeouts.
+- Each Phabricator revision must carry either real test coverage or one of the project's `{nav, name=testing-exception-*}` tags with a justification.
 
-## Constants, Prefs & Magic Numbers
-- Centralize shared values (bandwidth thresholds, max bandwidth, support URLs, pref names) in `ipprotection-constants.mjs` or the relevant `*Helpers.sys.mjs`, and import them everywhere they're referenced. Literals like `50`, `150`, `0.75`, `0.9` in component code or Fluent strings are review-blocking.
-- Pass user-visible numeric values (bandwidth caps, remaining usage) through Fluent `$variables`; never hardcode units or amounts inside `.ftl` messages. Units (`MB`, `GB`) must be hardcoded into the message text, not passed as variables, since localizers translate them differently.
-- Every new pref should be documented under `browser/components/ipprotection/docs/Preferences.rst` (or the toolkit equivalent) with correct type.
+## Active Campaigns (transient)
 
-## Localization
-- Any semantic change to a Fluent string requires a new ID and a Fluent migration under `python/l10n/fluent_migrations/` so translations aren't lost. Dropping an old ID is a separate, deliberate step once no callers remain.
-- Don't hardcode country or region names; use `Intl.DisplayNames` / `Services.intl.DisplayNames` and a single parameterized string.
-- Fluent comments attach only to the immediately following message — copy the comment for each message that needs it, and use standalone/group comments appropriately.
-- New user-facing strings belong in `browser/locales/en-US/browser/ipProtection.ftl` and must be wired into `browser.xhtml` outside the "Untranslated FTL" block.
+- **Module split — `browser/` → `toolkit/`**: the state machine, proxy manager, channel filter, and network helpers are migrating into `toolkit/components/ipprotection`; window/CustomizableUI/UI helpers remain in `browser/`. New service-layer code should land in `toolkit/`; `browser/`-only APIs (CustomizableUI, EveryWindow, dialogs) must not be pulled into `toolkit/` files. *Context: likely to fade once the toolkit move and the GeckoView abstraction are complete.*
+- **State-machine refactor**: `IPPService` and `IPPProxyManager` are converging on an explicit state enum (`READY`, `ACTIVATING`, `ACTIVE`, `PAUSED`, `ERROR`, `NOT_READY`, …) with `#computeState`/`#setState` rather than ad-hoc booleans. New code should drive UI off these states (and `IPPProxyManager:StateChanged`) and avoid adding parallel boolean flags. *Context: likely to fade once all helpers and tests are migrated and the legacy `isActive`/`isError` getters are removed.*
+- **Bandwidth & onboarding messaging**: in-panel warnings, infobar warnings, callouts, and the paused dialog are all reading from a shared bandwidth threshold pref + an onboarding bitmask. Use the existing helpers (`IPPOnboardingMessageHelper`, `IPProtectionInfobarManager`, `IPProtectionAlertManager`) and the threshold constants in `ipprotection-constants.mjs`; don't introduce a new place that hardcodes 75/90/100 thresholds. *Context: likely to fade once the messaging surface stabilises post-launch.*
 
-## Panel UI, Theming & Accessibility
-- Use design-system tokens (`--space-*`, `--border-color-card`, `--icon-color`, `--font-weight-*`, `--dimension-*`) instead of raw pixel values or hardcoded colors; SVG assets that need theming must use `context-fill` / `context-stroke` and let CSS set the color.
-- Prefer logical properties (`padding-block-*`, `padding-inline-*`, `margin-block-*`) so layouts work in RTL. Any directional glyph (`arrow-right`, etc.) or hand-rolled class like `left`/`right` is a red flag.
-- Reuse existing shared icons under `toolkit/themes/shared/icons/` before adding new SVGs; optimize any new SVG (e.g. via SVGOMG) and place module illustrations under `browser/components/ipprotection/assets/` (not `browser/base/content/logos/`).
-- Prefer `moz-button` / `moz-card` and existing panel conventions (`subviewbutton-nav`, overflow attributes) over re-implementing styles; avoid overriding `--arrowpanel-*` variables when a local margin/padding change will do.
-- Toolbar-button state must not rely on `overflows="true"` to detect overflow — check `overflowedItem="true"` or `cui-areatype="panel"` (or set `subviewbutton-nav` at creation time).
-- Keyboard focus, screen-reader announcements, and HCM outlines are required for every new interactive element. For toggles and buttons inside the panel, verify the accessible name and pressed state with NVDA/VoiceOver/Orca before r+.
+## Common Pitfalls
 
-## Testing
-- Manage prefs in tests with `SpecialPowers.pushPrefEnv`; it auto-reverts on teardown, so don't add manual `clearUserPref` cleanup for prefs it set.
-- Do not use `TestUtils.waitForCondition` to await things that can be observed deterministically; resolve a promise from inside the stub/handler you care about. This is a 100 ms-per-check polling cost that compounds across CI.
-- New panel/state/service behavior needs a corresponding `browser/xpcshell` test. Use the project tag `testing-approved`, or one of the documented exceptions with a one-line justification, on every revision.
-- When stubbing manager state, use the existing patterns in `browser_ipprotection_*` tests (e.g. `sandbox.stub(IPPProxyManager, "state").value(...)`) and `setupVpnPrefs` / `cleanupStatusCardTest` helpers rather than reinventing setup.
+- Hardcoding bandwidth limits, percentages, or country/flag mappings inline instead of pulling from `ipprotection-constants.mjs` or the entitlement.
+- Importing privileged ESMs (Services, ChromeUtils, FxAccounts, PrivateBrowsingUtils) into a `content/*.mjs` Lit component.
+- Mutating `this.state` from a content component or from outside `IPProtectionPanel.setState`, causing two windows to disagree.
+- Forgetting `composed: true` (or `bubbles: true`) on a `CustomEvent` dispatched from a shadow-DOM component, so `IPProtectionPanel` never sees it.
+- Adding event listeners or pref observers in `init` without a matching `removeEventListener` / `removeObserver` in `uninit` (or `disconnectedCallback` for components).
+- Comparing rendered Fluent text in tests instead of asserting `data-l10n-id`/`data-l10n-args`; or hardcoding English in `ok`/`is` messages.
+- Using `margin-left`/`right`, physical `border-radius` corners, `transform: scaleX(-1)` on text-bearing elements, or omitting `text-align: match-parent` when forcing `direction: ltr` on URL/path fields.
+- Calling `Math.floor` / `Math.round` / `toFixed` inconsistently across the panel, infobar, and settings page so the same value renders differently.
+- Opening links from a chrome panel via a raw `<a href>` click — use `openWebLinkIn`/`openTrustedLinkIn` (or `moz-support-link` for SUMO) and dispatch an `IPProtection:Close` event when appropriate.
+- Adding a new toolbar/panel widget without registering it through `CustomizableUI` and handling `onWidgetRemoved` / overflow (`cui-areatype`, `overflowedItem`, `subviewbutton-nav`) cases.
+- Persisting bandwidth, sign-in, or "ever turned on X" state across accounts/profile resets because the relevant pref or cache wasn't cleared on sign-out / entitlement change.
+- Logging or asserting on `console.log` left in tests; missing `sandbox.restore()` / stub cleanup.
 
-## Data Collection
-- Any change touching `metrics.yaml` must carry a `#data-classification-*` tag with a one-line justification, and the `data_sensitivity` property must match. Add `vpn-telemetry@mozilla.com` to `notification_emails` for new IPP metrics.
-- Prefer `counter`/`event` metrics over bespoke aggregation; record state transitions (e.g. "was active before pause") rather than current state when the event already implies it.
+## File-Glob Guidance
 
-## Proxy & Channel Filtering
-- When excluding a channel from IPP, pass through `defaultProxyInfo` to `onProxyFilterResult` — never `null` — so the user's system proxy is honored.
-- Prefer `nsIIOService::hostnameIsLocalIPAddress` (and related platform APIs) over regex for IP/host classification.
-- Lifecycle pairing: any code path that starts a channel filter, connection, or abort controller must have a matching teardown (`cancelChannelFilter`, `stop`, abort reason) in every exit path, including error and paused transitions.
+- `browser/components/ipprotection/content/*.mjs` — Lit components only. No privileged imports, no direct pref reads, no global side effects at module top level. Expose nodes via query decorators; emit `IPProtection:*` events for the panel to handle.
+- `browser/components/ipprotection/content/*.css` — Use design tokens; logical properties only; gate stylelint exceptions explicitly via `stylelint-rollouts.config.js` rather than scattering disable comments. Match the `panelUI-shared` token names where the panel embeds standard chrome chrome.
+- `browser/components/ipprotection/IPProtection*.sys.mjs` — Window/CustomizableUI/EveryWindow glue. Bind `handleEvent` once in the constructor, weak-ref windows, and never reach into a content component's shadow DOM directly.
+- `toolkit/components/ipprotection/IPP*.sys.mjs` — Cross-platform service, proxy manager, channel filter, network observers. Must stay free of `browser/`-only modules (CustomizableUI, gBrowser, dialog helpers). State changes are dispatched as events on the singleton.
+- `browser/components/ipprotection/assets/**/*.svg` — Run through svgo/SVGOMG; use `context-fill` / `context-stroke` and `-moz-context-properties` so icons follow `--icon-color`. No editor metadata, no hardcoded brand colors.
+- `browser/locales/en-US/browser/ipProtection.ftl` — Lowercase-dashed IDs, comments above each message giving developer context; group by panel surface. New IDs require fluent-reviewers approval.
+- `browser/components/ipprotection/metrics.yaml` — All new events get `vpn-telemetry@mozilla.com` plus the module owner on `notification_emails`, and a bug link in `bugs`. Prefer `counter`/`event` with typed `extra_keys` over free-form strings.
+- `browser/components/ipprotection/tests/{browser,xpcshell}/**` — Use the shared `head.js` helpers (`openPanel`, `setPanelState`, `triggerPausedState`, `DEFAULT_SERVICE_STATUS`); add new helpers there rather than copy-pasting setup. Stub network and FxA. Clear all VPN prefs in `registerCleanupFunction`.
+- `browser/components/ipprotection/docs/**` — New states, error codes, prefs, and helpers must be reflected here in the same patch.
 
-# Active Campaigns (transient)
+## Review Checklist
 
-- **Move IPP into `toolkit/`**: New non-UI logic (state machine, proxy manager, guardian client, auth provider) should land in `toolkit/components/ipprotection/` and avoid depending on desktop-only singletons (`CustomizableUI`, `EveryWindow`, etc.); platform-specific glue lives under `fxa/` or `android/` subdirs. Context: likely to fade once the Android/Fenix integration is fully wired up and the `browser/` → `toolkit/` migration is complete.
-- **Auth provider abstraction**: New FxA/Guardian code should go through `IPPAuthProvider` rather than reaching into `GuardianClient` singletons; avoid introducing cycles between `IPPService` and auth helpers. Context: likely to fade once the provider refactor lands and stabilizes.
-- **Bandwidth rounding consolidation**: Remaining/used bandwidth is currently rounded in several places (`bandwidth-usage`, `ipprotection-content`, `IPProtectionInfobarManager`); new callers should factor through a shared helper rather than re-implementing `Math.floor` / `toFixed` logic. Context: likely to fade once a single rounding utility is extracted.
+- [ ] Service/UI separation respected: content stays declarative, privileged work stays in `*.sys.mjs`, and toolkit code stays platform-agnostic.
+- [ ] State changes go through `setState` / `#setState`; events use `IPProtection:*` / `IPPProxyManager:*` names with `bubbles: true, composed: true` where they cross shadow DOM.
+- [ ] Every `init`/observer/event listener has a matching teardown; weak window refs where applicable; no leaked sandboxes/stubs in tests.
+- [ ] All new strings are Fluent with stable lowercase-dashed IDs and developer comments; `data-l10n-args` used for variables; no English literals in JS.
+- [ ] Logical CSS properties and design tokens used; RTL spot-checked; HCM border/outline still visible (no reliance on `box-shadow` for focus).
+- [ ] Toolbar/panel widget changes handle creation, overflow menu, removal, multi-window, and CustomizableUI placement restoration.
+- [ ] Prefs registered in `firefox.js`, documented under `docs/`, read via lazy pref getter or observer with cleanup; no content-side pref reads.
+- [ ] Bandwidth/entitlement values come from `IPPProxyManager.usageInfo` / startup cache; rounding and unit display match the rules in `ipprotection-constants.mjs` and other surfaces.
+- [ ] Telemetry: `metrics.yaml` updated with description, bug, and `vpn-telemetry@mozilla.com`; tests cover the new event or a `testing-exception-*` tag explains why.
+- [ ] Tests use shared helpers and stubs; assert on `data-l10n-id`/state rather than rendered text; clean up prefs, permissions, and stubs.
+- [ ] No hardcoded support URLs — use `app.support.baseURL` + a slug from constants, or `moz-support-link`.
+- [ ] Patch description carries a clear test plan and the appropriate `{nav, name=testing-*}` tag.
 
-# Common Pitfalls
+## House style references
 
-- Using `Math.floor` for remaining bandwidth where UX expects one-decimal precision (notably at the 75% bucket), or inverting the progress bar by binding it to `remaining` instead of `used`.
-- Dispatching events from one component while mutating the same state property directly in another, leading to drift between the panel and child components.
-- Adding a new button/toggle without wiring `data-l10n-id` accessibility attributes, or duplicating an aria-label that's already provided by `tooltiptext`.
-- Firing an ASRouter trigger unconditionally and encoding the gating logic in JS, instead of passing context properties and letting `targeting` decide.
-- Adding feature callouts without the `cfr` group, without `previousSessionEnd`, or without `!hasActiveEnterprisePolicies && !activeNotifications`. Omitting `dismiss: true` on CTA button actions.
-- Landing a permanent promotional message in-tree without a `lifetime` frequency cap and without considering a Nimbus rollout for safe kill-switching.
-- Starting an abort controller / channel filter but not clearing it on every exit path (error, paused, stop-while-activating).
-- Creating new icon SVGs that duplicate existing ones in `toolkit/themes/shared/icons/`; placing state illustrations in `browser/base/content/logos/`.
-- Forgetting the Fluent migration when renaming a user-facing string ID, or leaving the old ID around after all call sites are updated.
-- Running `mach lint` failures (fluent-lint, eslint, stylelint, file-whitespace) through to review; these should be clean before requesting review.
-- Editing `mots.yaml` without running `mots clean`.
-
-# File-Glob Guidance
-
-- `browser/components/ipprotection/content/*.mjs` — Components must read from `this.state` populated by `IPProtectionPanel`; they should dispatch `CustomEvent`s upward rather than mutating panel state. Use logical CSS properties and design tokens.
-- `browser/components/ipprotection/IPProtection*.sys.mjs` — Panel/manager/alert code owns state mutations and pref observers. Prefer `setState` batching; document new prefs in `docs/Preferences.rst`.
-- `toolkit/components/ipprotection/**` — Keep cross-platform-safe (no `CustomizableUI`, `EveryWindow`, `browser/`-only imports). Platform-specific glue goes in `fxa/` or `android/` subdirs (campaign).
-- `browser/components/ipprotection/IPPChannelFilter.sys.mjs` — Always pass `defaultProxyInfo` through to excluded channels; store it alongside pending channels so reprocessing preserves it.
-- `browser/components/ipprotection/content/*.css` + `browser/themes/shared/**` — Use design tokens and logical properties; prefer `.toolbarbutton-icon` over raw `image`; reuse `subviewbutton-nav` for subview arrows.
-- `browser/locales/en-US/browser/ipProtection.ftl` — New/changed IDs require a migration. Pass numbers as `$variables`; hardcode units. Comments attach only to the next message.
-- `browser/components/asrouter/modules/FeatureCalloutMessages.sys.mjs` — New callouts belong in the `cfr` group with `previousSessionEnd`, `!hasActiveEnterprisePolicies && !activeNotifications`, and `dismiss: true` on CTA buttons.
-- `**/metrics.yaml` — New metrics need data-classification tag, matching `data_sensitivity`, and `vpn-telemetry@mozilla.com` in notifications.
-- `browser/components/ipprotection/tests/**` — Prefer `SpecialPowers.pushPrefEnv` and promise-resolving stubs over `waitForCondition`; reuse existing `head.js` helpers.
-- `browser/components/ipprotection/docs/**` — Keep `StateMachine.rst`, `Preferences.rst`, `Constants.rst`, `Components.rst` in sync with code changes in the same patch.
-
-# Review Checklist
-
-- [ ] `mach lint --outgoing` clean (eslint, stylelint, fluent-lint, file-whitespace, rejected-words).
-- [ ] State mutations go through `setState`; no cross-file direct state writes.
-- [ ] No magic numbers for thresholds/caps/URLs — constants imported from the shared module.
-- [ ] New/changed Fluent IDs have a migration; units hardcoded; numbers passed as `$variables`.
-- [ ] New prefs documented in `docs/Preferences.rst` and use matching constants in code.
-- [ ] SVGs use `context-fill`/`context-stroke`; tokens (not pixel literals) drive spacing and color; logical properties used.
-- [ ] Accessibility verified: accessible name, pressed/toggled state, keyboard focus, HCM outlines.
-- [ ] Lifecycle balanced: every start/addObserver/addEventListener/AbortController has a matching teardown on all paths.
-- [ ] Tests use `pushPrefEnv` and promise-based stubs; no `waitForCondition` unless truly necessary; testing-policy tag applied.
-- [ ] `metrics.yaml` changes carry a data-classification tag and correct `data_sensitivity`; notification emails include `vpn-telemetry@mozilla.com`.
-- [ ] Docs (`StateMachine.rst`, `Components.rst`, etc.) updated in the same patch when behavior changes.
-- [ ] `mots.yaml` run through `mots clean` if touched.
+- [CSS Guidelines](https://firefox-source-docs.mozilla.org/code-quality/coding-style/css_guidelines.html)
+- [SVG Guidelines](https://firefox-source-docs.mozilla.org/code-quality/coding-style/svg_guidelines.html)
+- [RTL Guidelines](https://firefox-source-docs.mozilla.org/code-quality/coding-style/rtl_guidelines.html)
+- [JavaScript Coding Style](https://firefox-source-docs.mozilla.org/code-quality/coding-style/coding_style_js.html)
+- [Fluent for Firefox Developers](https://firefox-source-docs.mozilla.org/l10n/fluent/tutorial.html)

--- a/plugins/newtab/README.md
+++ b/plugins/newtab/README.md
@@ -9,3 +9,9 @@ Skills and tools for Firefox newtab development.
 Adds `@nova-cleanup` comments to Firefox newtab code for Project Nova parallel implementation tracking.
 
 Use this skill when adding cleanup comments to Nova-related changes. See [`skills/nova-cleanup-comments/SKILL.md`](skills/nova-cleanup-comments/SKILL.md) for details.
+
+### `home-newtab-review`
+
+Review guidance for Firefox's Home/New Tab module covering its React/JSX front-end, system modules, telemetry, train-hop compatibility, and design-token usage.
+
+Use this skill when reviewing changes under `browser/extensions/newtab/`, `browser/components/newtab/`, or related newtab metrics/preferences. See [`skills/home-newtab-review/SKILL.md`](skills/home-newtab-review/SKILL.md) for details.

--- a/plugins/newtab/skills/home-newtab-review/SKILL.md
+++ b/plugins/newtab/skills/home-newtab-review/SKILL.md
@@ -1,0 +1,162 @@
+---
+name: home-newtab-review
+description: Review guidance for Firefox's Home/New Tab module covering its React/JSX front-end, system modules, telemetry, train-hop compatibility, and design-token usage.
+---
+
+# Home/New Tab Review Skill
+
+## Standing Conventions
+
+### Train-hop compatibility (load-bearing)
+1. **Assume the New Tab XPI rides separately from the host application.** Any code under `browser/extensions/newtab/` may execute on host versions older than the one it was authored against. Code under `browser/components/newtab/`, `browser/modules/AboutNewTab*`, actors, IDL, IPDL, `firefox.js`, and `FeatureManifest.yaml` does *not* train-hop and ships with the host.
+2. **Feature-detect, then shim, then mark.** When calling a host API that may not exist on older supported versions, guard with `typeof X.method === "function"` (or equivalent) and provide a fallback. Annotate the shim with `@backward-compat { version N }` JSDoc so it can be removed once N reaches release. Three releases is the typical compatibility window.
+3. **Default values for new prefs/Nimbus variables must be set in `ActivityStream.sys.mjs` `PREFS_CONFIG`,** not (only) in `firefox.js`. Prefs added to `firefox.js` alone are invisible on older hosts. Dynamic prefs (locale/region-derived) belong in `ActivityStream.sys.mjs`'s dynamic computation, never `firefox.js`.
+4. **New Nimbus features are not train-hoppable.** Use the `newtabTrainhop` co-enrollment feature with a `trainhopConfig.<feature>.<variable>` payload pattern, not new top-level entries in `FeatureManifest.yaml`. Read with `Prefs.values.trainhopConfig?.<feature>?.<var>` plus a system pref fallback.
+5. **String migrations and metric registrations land at least one cycle before the consuming train-hop.** New Fluent IDs added in version N can only be referenced by an XPI targeting N or later; runtime metrics JSON for version N must exist before XPIs reference those metrics.
+
+### Localization
+1. **Never hardcode user-facing English in JSX or markup.** Use Fluent via `data-l10n-id` (and `data-l10n-args` where needed). For attribute-only strings, use `.label`/`.aria-label`/`.title` Fluent attributes.
+2. **Add a Fluent comment whenever the string's intent isn't obvious from the ID,** especially for short imperatives ("Report", "Hide") that are ambiguous between verbs and nouns to translators.
+3. **Prefer brand-new Fluent IDs over `-v2` suffixes** when the meaning of an existing string changes. Provide a Fluent migration recipe under `python/l10n/fluent_migrations/` and verify it with `./mach fluent-migration-test`.
+4. **Mind locale fallbacks during train-hops.** New locale strings are not present on older hosts; either gate the consuming code, ship the string ahead of time, or include the string in the XPI's bundled locales.
+
+### Accessibility & High Contrast Mode
+1. **Every interactive non-button element with a click handler needs a keyboard story.** Restrict key handlers to `Enter` and `Space`; never trigger on arbitrary keys.
+2. **Use the right semantic element first.** Dialogs use `<dialog>`; menus use `panel-list`; toggles use `moz-toggle`; section headings follow document outline (don't skip levels). Reach for `role=` only when the semantic element doesn't fit.
+3. **`aria-expanded`, `aria-haspopup`, `aria-label`, `aria-labelledby` are not optional** on context-menu buttons, dialog triggers, or icon-only controls. Position-in-set information (`aria-posinset`/`aria-setsize`) belongs on grouped lists with non-list parents.
+4. **HCM (`forced-colors`) must be considered for any new component.** Use `ButtonText`, `SelectedItem`, `Canvas`, `CanvasText` system colors; never rely on `box-shadow` for borders/focus rings; reset gradients to `Canvas` rather than reimplementing them.
+5. **`disabled` buttons need the `disabled` attribute,** not just CSS. CSS-only "disabled" still receives focus and click events.
+
+### Design tokens & theming
+1. **Use Acorn design tokens (`--space-*`, `--font-size-*`, `--border-radius-*`, `--color-*`, `--border-color-selected`, etc.) over literal values.** When a token doesn't fit, push back on the design rather than introducing a magic number; only reach for raw px for image dimensions or pixel-level positioning of decorative elements.
+2. **Avoid `calc()` to combine two tokens.** If you need `calc(var(--space-large) + var(--space-xsmall))`, the design is asking for a value the system doesn't define — use the closest single token or raise the gap with design.
+3. **Use logical properties exclusively** (`margin-inline-*`, `padding-block-*`, `inset-inline-*`, `border-start-start-radius`). Reach for physical `left`/`right` only inside an explicitly LTR-forced subtree (e.g., URL/code display) and document why.
+4. **`@nova-cleanup` comment any code that exists only to bridge classic and Nova layouts** so it can be found and removed when Nova ships everywhere. Prefer `.nova-enabled & { ... }` nesting over forking entire SCSS files; only fork when the components diverge substantially.
+5. **Wallpapers and themes mean text colors aren't fixed.** Use `--newtab-contextual-text-primary-color` and the contextual contrast mixins for anything overlaying user-controlled backgrounds.
+
+### Telemetry & data
+1. **Don't introduce new top-level Glean categories without need.** Reuse existing newtab probes; share descriptions via YAML anchors (`&name`/`*name`) when the same field appears in multiple metrics.
+2. **Set `data_sensitivity` correctly:** `technical` for app/runtime state, `interaction` for user-driven events. `_enabled` flags are almost always `technical`.
+3. **`newtab-content` ping submissions are randomized** through `NewTabContentPing`'s session policy; never call `submit()` directly from feature code. Respect `MAX_UINT32` normalization for any sampling helper that produces 0.0–1.0 values.
+4. **Update runtime-metrics JSON files for any metric/ping schema change** intended to ride a train-hop, and add `no_lint: [COMMON_PREFIX]` to runtime-registered metrics that share a prefix.
+5. **Tests of telemetry-emitting code assert the dispatched action / metric arguments, not formatted output.** Use `getAttributes` and verify `data-l10n-id` rather than the rendered string; assert metric `.testGetValue()` rather than scraping the DOM.
+
+### State, prefs, and feed wiring
+1. **Read prefs through Redux state (`this.props.Prefs.values.<name>` or `this.store.getState().Prefs.values.<name>`)**, not `Services.prefs.*`, in feed and component code. The PrefsFeed is the single bridge.
+2. **Bind feed methods on construction.** Pattern: `this.onPrefChangedAction = this.onPrefChangedAction.bind(this);` in the feed's constructor before observers attach.
+3. **`init`/`uninit` must be symmetric.** Every observer, listener, or worker spun up in `init` must be torn down in `uninit`. Re-`init` should be safe even after `uninit`.
+4. **Pref name constants live in `content-src/lib/PrefsConstants.mjs`** for shared use; widget-scoped prefs may live in the widget's registry module. Don't re-declare the same string literal across components.
+5. **System prefs (`*.system.*`) are computed/dynamic; user prefs are user-controlled.** A feature gated by both should evaluate as `systemPref || nimbusVariable` (Nimbus wins when set), and the pref the user toggles in Customize is the user pref, not the system pref.
+
+### Performance & threading
+1. **Heavy per-pixel or large-data work belongs in a PromiseWorker,** not on the parent process main thread. Terminate the worker after the one-shot job; don't keep it alive for rare events.
+2. **Don't re-fetch what's already in `PersistentCache`.** Cache reads are in-memory after the first load.
+3. **Be cautious with `setState` in `componentDidUpdate`** and similar lifecycle hooks; gate updates on actual value changes to avoid render loops.
+4. **Avoid `backdrop-filter: blur()`** in newtab styles until performance issues there are resolved; prefer translucent backgrounds.
+
+### Build, bundling, and tooling
+1. **JSX/SCSS edits require `./mach newtab bundle`** before the patch is ready for review. The generated `activity-stream.bundle.js` and compiled CSS must be committed in the same patch as their sources.
+2. **Don't hand-edit `activity-stream.bundle.js`, `activity-stream.css`, or files under `webext-glue/locales/`.** They are generated.
+3. **Per-file coverage thresholds are enforced.** New components need Jest tests sufficient to keep `karma.mc.config.js` thresholds green; add component-stub tests when adding components, even if behavior tests come later.
+4. **Sanitize SVG assets through `svgo`** (no editor metadata, no DOCTYPE, lowercase short hex colors, no excessive numeric precision). PNG assets need optimization before landing.
+5. **Use `moz-src://` URIs via the newtab `moz-src` helper** for new module imports inside the addon, while keeping a `resource://` fallback for older hosts during the trainhop window.
+
+## Active Campaigns (transient)
+
+### Nova layout migration
+The new tab is migrating from the classic responsive layout to the Nova grid system (`nova.enabled` pref). Code paths must work in both modes; new components target Nova first and use `.nova-enabled &` overrides or `@nova-cleanup` markers for legacy support. **Context: likely to fade once Nova graduates and the `nova.enabled` pref is removed.**
+
+### Pocket → Recommended Stories deprecation
+Pocket-branded UI, prefs (`extensions.pocket.*`), and telemetry events (Save/Archive/Delete from Pocket, Pocket logged-in CTA) are being removed; "Recommended stories" is the user-facing label. Don't add new Pocket references; remove referenced strings/icons/CSS when removing components. **Context: likely to fade once all Pocket references are stripped.**
+
+### Productivity widgets (Lists / Focus Timer / Weather Forecast / Sports / Clocks)
+Widgets share a common container, telemetry shape (`widget_name`, `widget_size`, `action_value`), and size-prefs pattern (`widgets.<name>.size`). New widgets should follow the existing scaffolding: registry constants, feed module, JSX component, customize-panel toggle, unified-telemetry helper. **Context: likely to fade once the widget set stabilizes and the unified telemetry shape ossifies.**
+
+### Settings redesign for Firefox Home
+`about:preferences#home` is being restructured into grouped `setting-group`/`moz-box-item` markup with new icons, dropdowns, and migration recipes. Coordinate with `#settings-reviewers` and supply Fluent migrations. **Context: likely to fade once the redesign ships and existing markup is removed.**
+
+## Common Pitfalls
+
+- Editing `activity-stream.bundle.js` or compiled CSS directly instead of bundling.
+- Adding a Nimbus feature/variable to `FeatureManifest.yaml` for a behavior that needs to train-hop, instead of using `trainhopConfig`.
+- Adding a pref to `firefox.js` and forgetting `ActivityStream.sys.mjs`'s `PREFS_CONFIG`, breaking older hosts.
+- Removing a host-side API or string in the same cycle that the XPI starts using it, breaking the trainhop window.
+- Hardcoding English strings in JSX, or using a single Fluent ID with `aria-label` instead of `data-l10n-id` + `.aria-label`.
+- Mutating Redux state from a render path or returning early before a hook runs, producing React error #310.
+- Using physical `left`/`right` properties or non-token padding/margin values; combining two tokens with `calc()`.
+- Triggering click handlers on arbitrary keys (Tab, Esc) instead of just Space/Enter; relying on hover-only visibility for context-menu buttons.
+- Forgetting to remove observers/listeners in `uninit`, leaking across feed re-inits.
+- Asserting against rendered Fluent text in tests, which breaks when localization markers (bidi, accents, pseudolocale) are inserted.
+- Sending telemetry from `componentDidMount` rather than via an `IntersectionObserver`, which over-counts preloaded newtab impressions.
+- Iterating large image data on the main thread instead of a PromiseWorker.
+
+## File-Glob Guidance
+
+### `browser/extensions/newtab/lib/**/*.sys.mjs` (feeds, services)
+- This code train-hops; treat host APIs as feature-detected.
+- Bind methods, symmetric init/uninit, read state via the Redux store rather than direct service calls when possible.
+- Add `@backward-compat` markers around shims (campaign).
+
+### `browser/extensions/newtab/content-src/components/**/*.jsx`
+- Pure presentational + small lifecycle; heavy logic goes in feeds.
+- Annotate Nova-only branches with `@nova-cleanup` (campaign).
+- New components ship with at least a stubbed Jest test.
+- Use design tokens for all spacing/color/typography.
+
+### `browser/extensions/newtab/content-src/**/_*.scss`
+- Logical properties only; tokens over literals; no `!important` without a comment.
+- Nest `.nova-enabled &` overrides rather than forking files (campaign).
+- HCM (`forced-colors`) considered explicitly.
+
+### `browser/extensions/newtab/lib/**/*Feed.sys.mjs` and `lib/Widgets/**`
+- Follow the action-handler switch pattern; dispatch through Redux `BroadcastToContent`/`OnlyToOneContent`.
+- `init`/`uninit` symmetry; cache reads/writes go through `PersistentCache`.
+
+### `browser/components/newtab/**`, `browser/modules/AboutNewTab*.sys.mjs`, `browser/actors/AboutNewTab*.sys.mjs`
+- Host-side: ships with Firefox, does *not* train-hop.
+- Changes here require coordinating with the trainhop XPI's expectations.
+
+### `browser/extensions/newtab/webext-glue/metrics/runtime-metrics-*.json`
+- One file per supported host version; required for trainhop metric registration.
+- Run `./mach lint --fix --outgoing` before submitting; missing `extra_args_types` allowlist entries cause silent registration failures.
+
+### `browser/components/newtab/metrics.yaml`, `pings.yaml`
+- Reuse existing categories; share descriptions via YAML anchors.
+- Correct `data_sensitivity`; document new fields with `description:` text translators/analysts can read without context.
+
+### `browser/components/preferences/home.*` and related
+- Coordinate with `#settings-reviewers` (campaign).
+- Provide Fluent migration recipes for renamed/repurposed strings; test with `./mach fluent-migration-test`.
+
+### `toolkit/components/nimbus/FeatureManifest.yaml`
+- Adding to top-level features is not train-hop compatible — use `newtabTrainhop` instead unless the feature ships with the host.
+
+### `browser/extensions/newtab/test/**`
+- Jest for components, xpcshell for feeds/services, browser-mochitest for end-to-end UI.
+- Don't assert against Fluent-rendered text; assert against Fluent IDs and dispatched actions.
+
+## Review Checklist
+
+1. Does any new code under `browser/extensions/newtab/` call a host API that might not exist on the trainhop window's oldest version? If so, is it feature-detected and `@backward-compat`-tagged?
+2. Are new prefs defined with defaults in `ActivityStream.sys.mjs` `PREFS_CONFIG`?
+3. Are new Nimbus variables routed through `trainhopConfig` rather than added as top-level features?
+4. If JSX/SCSS changed, was `./mach newtab bundle` run and the bundle committed?
+5. Are user-facing strings in Fluent with comments where intent is ambiguous? Are migrations supplied for renamed strings?
+6. For interactive elements: keyboard story (Space/Enter only), correct ARIA, HCM-tested, focus visible?
+7. For styles: design tokens (no magic numbers, no two-token `calc`), logical properties, contextual color tokens for wallpaper-aware text?
+8. Are observers, workers, and listeners torn down in `uninit`? Is re-`init` safe?
+9. Are tests asserting on dispatched actions / metric values / Fluent IDs rather than rendered strings?
+10. Are runtime-metrics JSON files updated for any metric/ping change that needs to ride a trainhop?
+11. Does any per-pixel / large-data work run on the main thread instead of a PromiseWorker?
+12. If this is a Nova-only change, is it gated and `@nova-cleanup`-tagged for later removal?
+
+## House style references
+
+- [CSS Guidelines](https://firefox-source-docs.mozilla.org/code-quality/coding-style/css_guidelines.html)
+- [SVG Guidelines](https://firefox-source-docs.mozilla.org/code-quality/coding-style/svg_guidelines.html)
+- [RTL Guidelines](https://firefox-source-docs.mozilla.org/code-quality/coding-style/rtl_guidelines.html)
+- [JavaScript Coding Style](https://firefox-source-docs.mozilla.org/code-quality/coding-style/coding_style_js.html)
+- [Python Coding Style](https://firefox-source-docs.mozilla.org/code-quality/coding-style/coding_style_python.html)
+- [C++ Coding Style](https://firefox-source-docs.mozilla.org/code-quality/coding-style/coding_style_cpp.html)
+- [Using C++ in Firefox Code](https://firefox-source-docs.mozilla.org/code-quality/coding-style/using_cxx_in_firefox_code.html)
+- [Fluent Localization Tutorial](https://firefox-source-docs.mozilla.org/l10n/fluent/tutorial.html)


### PR DESCRIPTION
Adds accessibility-frontend-review (new accessibilityfrontend plugin), desktop-theme-review (new desktoptheme plugin), and home-newtab-review (under the existing newtab plugin). Updates the ipprotection-review skill body with the current Lit/state-machine conventions.