### PR TITLE
Add Figma MCP

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,6 +12,10 @@
     {
       "name": "ipprotection",
       "source": "./plugins/ipprotection"
+    },
+    {
+      "name": "figma",
+      "source": "./plugins/figma"
     }
   ]
 }

--- a/plugins/figma/.claude-plugin/plugin.json
+++ b/plugins/figma/.claude-plugin/plugin.json
@@ -1,0 +1,5 @@
+{
+  "name": "figma",
+  "description": "Figma remote MCP server for Firefox UX implementation and design review",
+  "version": "1.0.0"
+}

--- a/plugins/figma/.mcp.json
+++ b/plugins/figma/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "figma": {
+      "type": "http",
+      "url": "https://mcp.figma.com/mcp"
+    }
+  }
+}

--- a/plugins/figma/README.md
+++ b/plugins/figma/README.md
@@ -1,0 +1,25 @@
+# Firefox Figma Plugin
+
+MCP server configuration for translating Figma designs into Firefox UI
+code and for reviewing UX implementations against their Figma source.
+
+## MCP Server
+
+### `figma`
+
+Connects to Figma's hosted remote MCP server at `https://mcp.figma.com/mcp`.
+
+**First-run authentication:**
+
+The first time the agent calls a Figma tool, Claude Code will open a
+browser window and prompt you to sign in to Figma and grant access. The
+OAuth token is cached locally — you won't be asked again until it
+expires or is revoked.
+
+No API key, personal access token, or Figma desktop app is required.
+
+**What it exposes:**
+
+Tools for reading Figma files the authenticated user has access to,
+useful when implementing UX under `browser/`, `toolkit/`, or `mobile/`
+from a Figma mockup, or when reviewing a patch against its design.


### PR DESCRIPTION
Add Figma MCP for developers that uses Figma designs.  It prompts the user to authenticate at first run.