### PR TITLE
Update widget scaffold skill for the Widget Registry

### DIFF
--- a/plugins/newtab/skills/widgets-scaffold/SKILL.md
+++ b/plugins/newtab/skills/widgets-scaffold/SKILL.md
@@ -1,10 +1,29 @@
 ---
-description: Scaffolds a new Firefox New Tab widget with JSX, SCSS, prefs, telemetry, Widgets.jsx integration, and a draft test file. Use when the user wants to add a new widget to the New Tab page.
+description: Scaffolds a new Firefox New Tab widget with a registry entry, JSX, SCSS, prefs, telemetry, customize-panel + about:preferences integration, and a draft test file. Use when the user wants to add a new widget to the New Tab page.
 ---
 
 # New Tab Widget Scaffold
 
 Widgets live in `browser/extensions/newtab/content-src/components/Widgets/{Name}/`.
+
+The **Widget Registry** (`common/WidgetsRegistry.mjs`) is the single source of
+truth for every widget. Adding a widget is now mostly declarative: you add one
+registry entry plus one component-registry entry, and shared helpers
+(`isWidgetEnabled`, `resolveWidgetSize`, `resolveWidgetHasSidebar`,
+`getHideAllTargets`, `resolveWidgetOrder`) and shared UI (`useSizeSubmenu`,
+`MoveSubmenu`, `WidgetWrapper`) do the wiring that used to be hand-copied into
+`Widgets.jsx` and `Base.jsx`. Do **not** hand-wire enabled-logic, size
+derivation, hide-all, or the null-guard into those files anymore.
+
+## Naming convention (read first)
+
+The widget **id/key** and **telemetry name** must NOT contain the word
+"widget" — they already live under the `widgets.` pref namespace, so a `*Widget`
+suffix is redundant. Use `widgets.example.enabled`, telemetry `"example"` — not
+`widgets.exampleWidget.enabled` / `"example_widget"`. The Sports widget shipped
+with the redundant id `sportsWidget` and it caused a pref + telemetry bug that
+had to be fixed (its `telemetryName` is `"sports"`). Treat the Sports `*Widget`
+naming as legacy — do not copy it.
 
 ## Workflow
 
@@ -16,33 +35,76 @@ Ask the user to run the requirements script first:
 python3 {BASE_DIR}/scripts/gather_requirements.py
 ```
 
-The script asks all required questions and prints a widget spec summary.
+The script asks all required questions (including the registry fields:
+`telemetryName`, `order`, `validSizes`, `defaultSize`, `hasSidebar`, trainhop
+keys) and prints a widget spec plus a ready-to-paste `WIDGET_REGISTRY` entry.
 Wait for the user to paste that summary before proceeding.
 
 ### Step 2 — Plan
 
 Enter plan mode. Using the spec and the example in
-`references/ExampleWidget/`, propose the full list of files to
-create/modify before writing anything. Read `references/notes.md` for
-non-obvious requirements and gotchas.
+`references/ExampleWidget/`, propose the full list of files to create/modify
+before writing anything. Read `references/notes.md` for non-obvious requirements
+and gotchas.
 
-Files touched by every widget:
-1. `ActivityStream.sys.mjs` — register prefs (**do this first, then run `./mach build faster` before proceeding**)
-2. `Widgets/{Name}/{Name}.jsx` — new widget component. Add `PREF_NOVA_ENABLED = "nova.enabled"` and `PREF_{NAME}_SIZE = "widgets.{widgetKey}.size"` constants. Derive size as `prefs[PREF_{NAME}_SIZE] || "medium"`. After all hooks, add a `// @nova-cleanup(remove-gate)` comment followed by `if (!prefs[PREF_NOVA_ENABLED]) { return null; }` to gate the widget on Nova being enabled. Apply `col-4 ${widgetSize}-widget` unconditionally on the root element. Use the submenu pattern for resize (see notes.md — "Widget resize context menu"); do NOT use separate `<panel-item hidden={...}>` elements. Check `supportsSmallSize` from the spec — if `yes`, add `"small"` to the size map in the submenu.
-3. `Widgets/{Name}/_{Name}.scss` — widget styles. Add `&.medium-widget { grid-row: span 2; }` and `&.large-widget { grid-row: span 4; }` inside the root class. Add `&.small-widget { grid-row: span 1; }` only if `supportsSmallSize = yes`.
-4. `Widgets/Widgets.jsx` — import, enabled logic, null guard, JSX render
-5. `Widgets/_Widgets.scss` — add CSS class to `:has()` selector
-6. `test/jest/content-src/components/Widgets/{Name}.test.jsx` — create a dedicated test file for the new widget. The shared `Widgets.test.jsx` is for container/integration coverage only; per-widget tests live in their own file alongside the other widgets in that directory (e.g. `FocusTimer.test.jsx`, `Weather.test.jsx`)
-7. `content-src/styles/activity-stream.scss` — add `@import`
-8. `content-src/styles/nova/activity-stream.scss` — add `@import` (**required — without this, styles won't render in Nova mode**)
-9. `stylelint-rollouts.config.js` (repo root) — add the new widget's SCSS path in alphabetical order alongside the other widget entries
-10. `Base.jsx`, `CustomizeMenu.jsx`, `ContentSection.jsx`, `WidgetsManagementPanel.jsx` — Customize panel toggle (add prop to function signature, switch case, and `moz-toggle` in `WidgetsManagementPanel.jsx`)
-11. `AboutPreferences.sys.mjs` — register prefs, settings, and items in the Home group (`about:preferences#home`), set up in `_setupHomeGroup`
-12. `browser/locales/en-US/browser/newtab/newtab.ftl` — FTL strings for new tab
-13. `browser/locales/en-US/browser/preferences/preferences.ftl` — FTL string for `about:preferences` toggle
+The registry-centric core (do these first, in order):
 
-Additional files if the spec requires them:
-- `common/Actions.mjs` + `common/Reducers.sys.mjs` — only if Redux state is needed
+1. `common/WidgetsRegistry.mjs` — add the `WIDGET_REGISTRY` entry (next `order`
+   integer) and export the widget's pref-key constants
+   (`PREF_WIDGETS_{KEY}_ENABLED`, `PREF_{KEY}_SIZE`,
+   `PREF_WIDGETS_SYSTEM_{KEY}_ENABLED`). This replaces the old per-component
+   pref constants and the hand-wired enabled expressions — `isWidgetEnabled`
+   derives everything from the entry.
+2. `lib/ActivityStream.sys.mjs` — register the three prefs (**do this first,
+   then run `./mach build faster` before proceeding**). The size pref's `value`
+   is `""` (empty = "user hasn't chosen"; lets trainhop/`defaultSize` apply).
+3. `Widgets/{Name}/{Name}.jsx` — the widget component. Mirror
+   `references/ExampleWidget/ExampleWidget.jsx`:
+   - Look up its entry once: `const ENTRY = WIDGET_REGISTRY.find(w => w.id === "{key}")`.
+   - Derive size with `resolveWidgetSize(ENTRY, prefs)` — never read the size
+     pref directly.
+   - Accept the standard props: `dispatch`, `handleUserInteraction` (interactive
+     widgets only), `isMaximized`, `widgetsMayBeMaximized`, `widgetEnabledMap`.
+   - Resize submenu via the `useSizeSubmenu(handleChangeSize)` hook (do NOT
+     hand-roll the click listener). Gate the submenu on
+     `widgetsMayBeMaximized`. Include `"small"` only if `validSizes` has it.
+   - Reorder via `<MoveSubmenu widgetId="{key}" widgetEnabledMap={widgetEnabledMap} />`.
+   - Render its own `<article className="{css} widget col-4 ${widgetSize}-widget">`
+     root. Do **not** add a per-widget Nova gate — the container (`Widgets.jsx`)
+     renders `WIDGET_ROW_COMPONENTS` only in its Nova branch, so the widget already
+     mounts only under Nova; a `nova.enabled` early return here is redundant.
+     (Sports has one; it is legacy — do not copy it.)
+4. `Widgets/WidgetsComponentRegistry.jsx` — add the component to
+   `WIDGET_ROW_COMPONENTS`. If the spec has `hasSidebar: true`, also add a
+   sidebar component to `WIDGET_SIDEBAR_COMPONENTS` — see
+   `references/SidebarVariant.md` for that wiring.
+
+The supporting files (each widget still touches these):
+
+5. `Widgets/{Name}/_{Name}.scss` — styles. Add `&.medium-widget { grid-row: span 2; }`
+   and `&.large-widget { grid-row: span 4; }` inside the root class; add
+   `&.small-widget { grid-row: span 1; }` only if `validSizes` includes `"small"`.
+6. `content-src/styles/activity-stream.scss` — add `@import` of the widget SCSS.
+7. `stylelint-rollouts.config.js` (repo root) — add the SCSS path in alphabetical
+   order alongside the other widget entries.
+8. `lib/AboutPreferences.sys.mjs` + `browser/locales/en-US/browser/preferences/preferences.ftl`
+   — register the widget for `about:preferences#home` (see notes.md) with a
+   `home-prefs-{css-class}-header` string.
+9. Customize panel toggle (all required, see notes.md):
+   `Base.jsx` (compute `mayHave{Name}Widget` and pass it to **both**
+   `<CustomizeMenu>` renders) → `CustomizeMenu.jsx` (passthrough) →
+   `Nova/CustomizeMenu/WidgetsManagementPanel/WidgetsManagementPanel.jsx` (add
+   the `moz-toggle`) → `ContentSection.jsx` (classic path) →
+   `browser/locales/en-US/browser/newtab/newtab.ftl` (toggle label).
+10. `test/jest/content-src/components/Widgets/{Name}.test.jsx` — a dedicated Jest
+    test file. New tests go in Jest (not the legacy `test/unit/` Enzyme suite).
+
+Additional files only if the spec requires them:
+- `common/Actions.mjs` + `common/Reducers.sys.mjs` — only if Redux state is
+  needed. New `WIDGETS_*` action types must stay alphabetically sorted (a test
+  asserts it).
+- `lib/{Name}Feed.sys.mjs` — only if the widget needs a backend data feed (see
+  `WeatherFeed.sys.mjs`).
 
 ### Step 3 — Scaffold
 
@@ -59,9 +121,11 @@ explain what you found and what decision is needed before continuing.
 
 After scaffolding, the build artifacts must be regenerated:
 
-1. `./mach newtab bundle` — compile SCSS and JS (**`./mach build faster` alone does NOT recompile SCSS**)
+1. `./mach newtab bundle` — compile SCSS and JS (**`./mach build faster` alone
+   does NOT recompile SCSS**)
 2. `./mach build faster` — copy compiled artifacts to the build output
-3. Commit the build artifacts: `css/activity-stream.css`, `css/nova/activity-stream.css`, `data/content/activity-stream.bundle.js`
+3. Commit the build artifacts: `css/activity-stream.css`,
+   `css/nova/activity-stream.css`, `data/content/activity-stream.bundle.js`
 
 ### Step 5 — Follow-up
 
@@ -77,21 +141,24 @@ Then output the full enable instructions below:
 
 Set **all three** of these to `true`:
 - `browser.newtabpage.activity-stream.widgets.system.enabled` (parent gate for all widgets — defaults to `false`)
-- `browser.newtabpage.activity-stream.widgets.{widgetKey}.enabled`
-- `browser.newtabpage.activity-stream.widgets.system.{widgetKey}.enabled`
+- `browser.newtabpage.activity-stream.widgets.{key}.enabled`
+- `browser.newtabpage.activity-stream.widgets.system.{key}.enabled`
+
+(`{key}` is the registry id, with no `Widget` suffix.)
 
 **Option B — Nimbus trainhop**
 
 1. Install [Nimbus devtools](https://github.com/mozilla-extensions/nimbus-devtools/releases/tag/release%2Fv0.3.0)
 2. Choose "Feature configuration enrollment" on the left side
-3. Opt into an experiment for `newtabTrainhop` with:
+3. Opt into an experiment for `newtabTrainhop` with the entry's
+   `trainhopEnabledKey` (e.g. `{key}Enabled`):
 
 ```json
 {
   "type": "widgets",
   "payload": {
     "enabled": true,
-    "{widgetKey}Enabled": true
+    "{key}Enabled": true
   }
 }
 ```

--- a/plugins/newtab/skills/widgets-scaffold/references/ExampleWidget/ExampleWidget.jsx
+++ b/plugins/newtab/skills/widgets-scaffold/references/ExampleWidget/ExampleWidget.jsx
@@ -3,35 +3,46 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 // eslint-disable-next-line no-unused-vars
-import React, { useCallback, useEffect, useRef } from "react";
+import React, { useCallback, useRef } from "react";
 import { useSelector, batch } from "react-redux";
 import { actionCreators as ac, actionTypes as at } from "common/Actions.mjs";
-import { useIntersectionObserver } from "../../../lib/utils";
+import { useIntersectionObserver, useSizeSubmenu } from "../../../lib/utils";
+import { WIDGET_REGISTRY, resolveWidgetSize } from "common/WidgetsRegistry.mjs";
+import { MoveSubmenu } from "../MoveSubmenu";
 
 // Only present for interactive widgets. Remove entirely for view-only widgets.
 const USER_ACTION_TYPES = {
+  CHANGE_SIZE: "change_size",
   DO_THING: "do_thing",
-  DO_OTHER_THING: "do_other_thing",
 };
 
-const PREF_NOVA_ENABLED = "nova.enabled";
+// Constants for any extra widget-specific prefs read inside this component.
+// The enabled/system.enabled/size prefs are owned by the registry — do not
+// redeclare them here. Omit this block if there are no extra prefs.
+const PREF_EXAMPLE_MAX_ITEMS = "widgets.example.maxItems";
 
-// Constants for any widget-specific prefs read inside this component.
-// Omit if no extra prefs beyond enabled/system.enabled.
-const PREF_EXAMPLE_WIDGET_MAX_ITEMS = "widgets.exampleWidget.maxItems";
-const PREF_EXAMPLE_WIDGET_SIZE = "widgets.exampleWidget.size";
+// Look the entry up once by registry id. NOTE: the id must NOT contain the
+// word "widget" — it lives under the `widgets.` pref namespace, so a suffix
+// like "exampleWidget" is redundant (and caused a real pref/telemetry bug on
+// the Sports widget). Use "example", not "exampleWidget".
+const EXAMPLE_ENTRY = WIDGET_REGISTRY.find(w => w.id === "example");
 
 function ExampleWidget({
   dispatch,
-  handleUserInteraction, // omit this param for view-only widgets
+  handleUserInteraction, // omit for view-only widgets
+  // eslint-disable-next-line no-unused-vars
+  isMaximized,
+  widgetsMayBeMaximized,
+  widgetEnabledMap,
 }) {
   const prefs = useSelector(state => state.Prefs.values);
   // If the widget has a Redux state slice:
   // const widgetData = useSelector(state => state.ExampleWidget);
 
-  const widgetSize = prefs[PREF_EXAMPLE_WIDGET_SIZE] || "medium";
+  // Size comes from the registry helper: user-set pref > trainhop suggestion
+  // > registry defaultSize. Never read the size pref directly.
+  const widgetSize = resolveWidgetSize(EXAMPLE_ENTRY, prefs);
   const impressionFired = useRef(false);
-  const sizeSubmenuRef = useRef(null);
 
   const handleIntersection = useCallback(() => {
     if (impressionFired.current) {
@@ -42,7 +53,8 @@ function ExampleWidget({
       ac.AlsoToMain({
         type: at.WIDGETS_IMPRESSION,
         data: {
-          widget_name: "example_widget",
+          // telemetryName from the registry entry (snake_case, no "widget").
+          widget_name: "example",
           widget_size: widgetSize,
         },
       })
@@ -51,10 +63,10 @@ function ExampleWidget({
 
   const widgetRef = useIntersectionObserver(handleIntersection);
 
-  // Call handleUserInteraction("<widgetKey>") after any interaction that should
-  // mark the widget as "interacted with" for the feature highlight flow.
+  // Call handleUserInteraction("<id>") after any interaction that should mark
+  // the widget as "interacted with" for the feature-highlight flow.
   const handleInteraction = useCallback(
-    () => handleUserInteraction("exampleWidget"),
+    () => handleUserInteraction("example"),
     [handleUserInteraction]
   );
 
@@ -66,7 +78,7 @@ function ExampleWidget({
         ac.OnlyToMain({
           type: at.WIDGETS_USER_EVENT,
           data: {
-            widget_name: "example_widget",
+            widget_name: "example",
             widget_source: "widget",
             user_action: USER_ACTION_TYPES.DO_THING,
             widget_size: widgetSize,
@@ -77,19 +89,19 @@ function ExampleWidget({
     handleInteraction();
   }
 
-  function handleExampleWidgetHide() {
+  function handleExampleHide() {
     batch(() => {
       dispatch(
         ac.OnlyToMain({
           type: at.SET_PREF,
-          data: { name: "widgets.exampleWidget.enabled", value: false },
+          data: { name: EXAMPLE_ENTRY.enabledPref, value: false },
         })
       );
       dispatch(
         ac.OnlyToMain({
           type: at.WIDGETS_ENABLED,
           data: {
-            widget_name: "example_widget",
+            widget_name: "example",
             widget_source: "context_menu",
             enabled: false,
             widget_size: widgetSize,
@@ -97,8 +109,6 @@ function ExampleWidget({
         })
       );
     });
-    // Only call handleInteraction() here if the widget is interactive.
-    handleInteraction();
   }
 
   const handleChangeSize = useCallback(
@@ -107,16 +117,16 @@ function ExampleWidget({
         dispatch(
           ac.OnlyToMain({
             type: at.SET_PREF,
-            data: { name: PREF_EXAMPLE_WIDGET_SIZE, value: size },
+            data: { name: EXAMPLE_ENTRY.sizePref, value: size },
           })
         );
         dispatch(
           ac.OnlyToMain({
             type: at.WIDGETS_USER_EVENT,
             data: {
-              widget_name: "example_widget",
+              widget_name: "example",
               widget_source: "context_menu",
-              user_action: "resize",
+              user_action: USER_ACTION_TYPES.CHANGE_SIZE,
               action_value: size,
               widget_size: size,
             },
@@ -127,20 +137,11 @@ function ExampleWidget({
     [dispatch]
   );
 
-  useEffect(() => {
-    const el = sizeSubmenuRef.current;
-    if (!el) {
-      return undefined;
-    }
-    const listener = e => {
-      const item = e.composedPath().find(node => node.dataset?.size);
-      if (item) {
-        handleChangeSize(item.dataset.size);
-      }
-    };
-    el.addEventListener("click", listener);
-    return () => el.removeEventListener("click", listener);
-  }, [handleChangeSize]);
+  // Shared hook: returns a ref to attach to the resize submenu's <panel-list>.
+  // It listens at the panel-list root and walks composedPath() to find the
+  // clicked size by its data-size attribute. Do NOT hand-roll this — React's
+  // synthetic onClick does not cross the panel-list shadow-DOM boundary.
+  const sizeSubmenuRef = useSizeSubmenu(handleChangeSize);
 
   function handleLearnMore() {
     batch(() => {
@@ -154,7 +155,7 @@ function ExampleWidget({
         ac.OnlyToMain({
           type: at.WIDGETS_USER_EVENT,
           data: {
-            widget_name: "example_widget",
+            widget_name: "example",
             widget_source: "context_menu",
             user_action: "learn_more",
             widget_size: widgetSize,
@@ -164,56 +165,63 @@ function ExampleWidget({
     });
   }
 
-  // @nova-cleanup(remove-gate): Remove this guard and PREF_NOVA_ENABLED after Nova ships
-  if (!prefs[PREF_NOVA_ENABLED]) {
-    return null;
-  }
+  // No per-widget Nova gate. The widgets container (Widgets.jsx) already renders
+  // WIDGET_ROW_COMPONENTS only in its Nova branch, so this widget mounts only when
+  // Nova is enabled — adding a `nova.enabled` early return here would be redundant.
 
-  const maxItems = prefs[PREF_EXAMPLE_WIDGET_MAX_ITEMS];
+  const maxItems = prefs[PREF_EXAMPLE_MAX_ITEMS];
 
   return (
     <article
-      className={`example-widget widget col-4 ${widgetSize}-widget`}
+      className={`example widget col-4 ${widgetSize}-widget`}
       ref={el => {
         widgetRef.current = [el];
       }}
     >
-      <div className="example-widget-title-wrapper">
-        <h3 className="newtab-example-widget-title">Example Widget</h3>
-        <div className="example-widget-context-menu-wrapper">
+      <div className="example-title-wrapper">
+        <h3 className="newtab-example-title">Example Widget</h3>
+        <div className="example-context-menu-wrapper">
           <moz-button
-            className="example-widget-context-menu-button"
+            className="example-context-menu-button"
             iconSrc="chrome://global/skin/icons/more.svg"
-            menuId="example-widget-context-menu"
+            menuId="example-context-menu"
             type="ghost"
           />
-          <panel-list id="example-widget-context-menu">
-            {/* Additional context menu items from spec go here, before size submenu */}
-            <panel-item submenu="example-widget-size-submenu">
-              <span data-l10n-id="newtab-widget-menu-change-size"></span>
-              <panel-list
-                ref={sizeSubmenuRef}
-                slot="submenu"
-                id="example-widget-size-submenu"
-              >
-                {/* Include "small" in the map only if spec supportsSmallSize = yes */}
-                {["medium", "large"].map(size => (
-                  <panel-item
-                    key={size}
-                    type="checkbox"
-                    checked={widgetSize === size || undefined}
-                    data-size={size}
-                    data-l10n-id={`newtab-widget-size-${size}`}
-                  />
-                ))}
-              </panel-list>
-            </panel-item>
+          <panel-list id="example-context-menu">
+            {/* Additional context menu items from the spec go here, first. */}
+
+            {/* Resize submenu — only when sizing is available in this layout.
+                Include "small" in the map only when validSizes contains it. */}
+            {widgetsMayBeMaximized && (
+              <panel-item submenu="example-size-submenu">
+                <span data-l10n-id="newtab-widget-menu-change-size"></span>
+                <panel-list
+                  ref={sizeSubmenuRef}
+                  slot="submenu"
+                  id="example-size-submenu"
+                >
+                  {["medium", "large"].map(size => (
+                    <panel-item
+                      key={size}
+                      type="checkbox"
+                      checked={widgetSize === size || undefined}
+                      data-size={size}
+                      data-l10n-id={`newtab-widget-size-${size}`}
+                    />
+                  ))}
+                </panel-list>
+              </panel-item>
+            )}
+
+            {/* Reorder submenu — shared component, reads widgets.order. */}
+            <MoveSubmenu widgetId="example" widgetEnabledMap={widgetEnabledMap} />
+
             <panel-item
               data-l10n-id="newtab-widget-menu-hide"
-              onClick={handleExampleWidgetHide}
+              onClick={handleExampleHide}
             />
             <panel-item
-              data-l10n-id="newtab-example-widget-menu-learn-more"
+              data-l10n-id="newtab-example-menu-learn-more"
               onClick={handleLearnMore}
             />
           </panel-list>
@@ -221,10 +229,10 @@ function ExampleWidget({
       </div>
 
       {/* Widget body */}
-      <div className="example-widget-body">
+      <div className="example-body">
         <p>Widget content goes here. Max items: {maxItems}</p>
         <moz-button
-          data-l10n-id="newtab-example-widget-do-thing"
+          data-l10n-id="newtab-example-do-thing"
           onClick={handleDoThing}
         />
       </div>

--- a/plugins/newtab/skills/widgets-scaffold/references/ExampleWidget/_ExampleWidget.scss
+++ b/plugins/newtab/skills/widgets-scaffold/references/ExampleWidget/_ExampleWidget.scss
@@ -4,7 +4,9 @@
 
 /* stylelint-disable stylelint-plugin-mozilla/use-design-tokens */
 
-.example-widget {
+// Root class is the css-class form of the registry id — no "-widget" suffix
+// (the shared `widget` class is applied alongside it). e.g. id "example".
+.example {
   @include newtab-card-style;
 
   border-radius: var(--border-radius-large);
@@ -13,6 +15,8 @@
   flex-direction: column;
   box-shadow: var(--box-shadow-card);
 
+  // Grid-row span per size. Add &.small-widget only if validSizes includes
+  // "small" (and the widget stays in the row, i.e. hasSidebar is false).
   &.medium-widget {
     grid-row: span 2;
   }
@@ -22,7 +26,7 @@
   }
 }
 
-.example-widget-title-wrapper {
+.example-title-wrapper {
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -35,14 +39,14 @@
   }
 }
 
-.example-widget-context-menu-wrapper {
+.example-context-menu-wrapper {
   opacity: 0;
   pointer-events: none;
 }
 
-.example-widget:hover,
-.example-widget:focus-within {
-  .example-widget-context-menu-wrapper {
+.example:hover,
+.example:focus-within {
+  .example-context-menu-wrapper {
     opacity: 1;
     pointer-events: auto;
   }
@@ -50,7 +54,7 @@
 
 // Widget-specific styles below.
 // Use design system tokens only — no hardcoded colors or spacing values.
-.example-widget-body {
+.example-body {
   flex: 1;
   display: flex;
   flex-direction: column;

--- a/plugins/newtab/skills/widgets-scaffold/references/SidebarVariant.md
+++ b/plugins/newtab/skills/widgets-scaffold/references/SidebarVariant.md
@@ -1,0 +1,83 @@
+# Sidebar variant (optional)
+
+Most widgets render in the widget row only. A widget can *also* render in the
+sidebar when its effective size is `"small"` — Weather is the only widget that
+does this today. You do **not** need this for a standard widget; reach for it
+only when the spec explicitly calls for a sidebar placement.
+
+The widget body (`ExampleWidget.jsx`) is unchanged — it already accepts a `size`.
+Only two things differ from the default scaffold: the registry entry gains a few
+fields, and `WidgetsComponentRegistry.jsx` registers a second component.
+
+## 1. Registry entry (`common/WidgetsRegistry.mjs`)
+
+Add `hasSidebar` and a trainhop sidebar key; make sure `validSizes` includes
+`"small"`:
+
+```js
+{
+  id: "example",
+  telemetryName: "example",
+  order: 5,
+  enabledPref: PREF_WIDGETS_EXAMPLE_ENABLED,
+  sizePref: PREF_EXAMPLE_SIZE,
+  defaultSize: "small",
+  validSizes: ["small", "medium", "large"],
+  hasSidebar: true,                      // <- moves to sidebar at size "small"
+  systemEnabledPref: PREF_WIDGETS_SYSTEM_EXAMPLE_ENABLED,
+  trainhopEnabledKey: "exampleEnabled",
+  trainhopSizeKey: "exampleSize",
+  trainhopSidebarKey: "exampleSidebar",  // <- null for non-sidebar widgets
+}
+```
+
+`hasSidebar` must be set explicitly: size alone is not enough, because a widget
+may support `"small"` and still stay in the row. `resolveWidgetHasSidebar(entry,
+prefs)` reads `trainhopSidebarKey` first (so trainhop can override placement),
+then falls back to the static `hasSidebar` flag.
+
+## 2. Component registry (`Widgets/WidgetsComponentRegistry.jsx`)
+
+Register two thin wrappers around the same widget component — one for the row,
+one for the sidebar. The row wrapper resolves the size from the registry and
+passes it as a `size` prop; the sidebar wrapper hard-codes `size="small"`:
+
+```jsx
+import { WIDGET_REGISTRY, resolveWidgetSize } from "common/WidgetsRegistry.mjs";
+
+const exampleEntry = WIDGET_REGISTRY.find(w => w.id === "example");
+
+function ExampleRowWidget({ dispatch, widgetEnabledMap }) {
+  const prefs = useSelector(state => state.Prefs.values);
+  const size = resolveWidgetSize(exampleEntry, prefs);
+  return (
+    <ExampleWidget
+      dispatch={dispatch}
+      size={size}
+      widgetEnabledMap={widgetEnabledMap}
+    />
+  );
+}
+
+function ExampleSidebarWidget({ dispatch }) {
+  return <ExampleWidget dispatch={dispatch} size="small" />;
+}
+
+export const WIDGET_ROW_COMPONENTS = {
+  // ...
+  example: ExampleRowWidget,
+};
+
+export const WIDGET_SIDEBAR_COMPONENTS = {
+  // ...
+  example: ExampleSidebarWidget,
+};
+```
+
+When you use the row-wrapper pattern, the widget component should read `size`
+from its props instead of calling `resolveWidgetSize` itself (compare Weather
+and Clocks, which take `size` as a prop, with Sports, which resolves its own).
+
+The container places the component automatically: `resolveWidgetHasSidebar`
+returning `true` at size `"small"` routes it to `WIDGET_SIDEBAR_COMPONENTS`;
+otherwise it renders in the row via `WIDGET_ROW_COMPONENTS`.

--- a/plugins/newtab/skills/widgets-scaffold/references/notes.md
+++ b/plugins/newtab/skills/widgets-scaffold/references/notes.md
@@ -3,375 +3,288 @@
 Things that are non-obvious from the ExampleWidget alone. Only update this file
 when a gotcha changes — if the example shows it clearly, it doesn't belong here.
 
-## New widgets are Nova-only
+## Widget naming convention — no "widget" suffix
 
-All widgets created after the Nova launch do not need classic-enabled fallbacks.
-Do not add `novaEnabled` conditionals, `.classic-enabled &` SCSS blocks, or
-`@nova-cleanup` comments to new widget files. Those patterns exist only in older
-widgets pending post-launch cleanup. New widget components also do not receive
-`isMaximized` or `widgetsMayBeMaximized` props.
+The widget **id/key** and **telemetry name** must NOT contain the word "widget".
+They already live under the `widgets.` pref namespace, so a `*Widget` suffix is
+redundant. Model the naming on Weather:
 
-Every new widget component must read `PREF_NOVA_ENABLED = "nova.enabled"` and
-return `null` early if it is `false` — placed after all hooks so React's rules
-of hooks are not violated. Mark it with a `// @nova-cleanup(remove-gate)`
-comment so it gets removed once Nova officially ships.
+- id `weather` → `widgets.weather.enabled`, `widgets.weather.size`,
+  `widgets.system.weather.enabled`, trainhop `weatherEnabled`, telemetry `"weather"`.
+
+The Sports widget got this wrong: it shipped as id `sportsWidget`
+(`widgets.sportsWidget.enabled`, trainhop `sportsWidgetEnabled`) and it caused a
+pref + telemetry bug that had to be fixed — its `telemetryName` is `"sports"`,
+NOT `"sports_widget"`. Treat the Sports `*Widget` naming as legacy. New widgets
+use the clean form (e.g. id `example`, telemetry `"example"`).
+
+## The Widget Registry is the source of truth
+
+`common/WidgetsRegistry.mjs` defines `WIDGET_REGISTRY` — one entry per widget —
+and the helpers that derive everything else. You no longer hand-wire enabled
+logic, size derivation, hide-all, or the null-guard into `Widgets.jsx` or
+`Base.jsx`. Adding a widget is mostly: add a registry entry + a
+`WIDGET_ROW_COMPONENTS` entry + register the prefs.
+
+Each entry's fields: `id`, `telemetryName`, `order`, `enabledPref`, `sizePref`,
+`defaultSize`, `validSizes`, `hasSidebar`, `systemEnabledPref`,
+`trainhopEnabledKey`, `trainhopSizeKey`, `trainhopSidebarKey`. Export the pref-key
+constants from this same file and register them in `ActivityStream.sys.mjs`.
+
+The helpers (use these; do not reimplement the logic in components):
+
+- `isWidgetEnabled(entry, prefs, widgetsEnabled)` — whether the widget is on.
+- `isWidgetAddable(entry, prefs)` — the system/trainhop gate, ignoring the user toggle.
+- `resolveWidgetSize(entry, prefs)` — the effective size (see below).
+- `resolveWidgetHasSidebar(entry, prefs)` — sidebar placement (trainhop override
+  then static flag).
+- `getHideAllTargets(prefs, widgetEnabledMap)` — the list "hide all" disables.
+- `resolveWidgetOrder(prefs)` / `getWidgetOrder(orderPref)` — render order.
+
+The registry's own top doc-comment is the canonical "ADDING A NEW WIDGET" recipe —
+read it before scaffolding.
+
+## Nova gating is container-level, NOT per-widget
+
+`nova.enabled` still defaults to `false` and `Widgets.jsx` keeps a dual render
+path: `if (novaEnabled) { …render WIDGET_ROW_COMPONENTS… } else { …legacy… }`.
+A new widget is registered only in `WIDGET_ROW_COMPONENTS`, so it mounts **only**
+in the Nova branch. That means the container already gates it on Nova — do **not**
+add a per-widget `if (!prefs[PREF_NOVA_ENABLED]) return null;` or a
+`@nova-cleanup(remove-gate)` comment to a new widget.
+
+SportsWidget *does* have a per-widget Nova gate; that is legacy and must not be
+copied. (Older widgets like FocusTimer/Lists also carry conditional Nova logic
+because they predate the registry — new widgets don't need any of it.)
+
+## Size: resolveWidgetSize and the empty-string sentinel
+
+`resolveWidgetSize(entry, prefs)` applies priority:
+1. user-set `sizePref` (non-empty) — always wins
+2. `trainhopConfig.widgets[trainhopSizeKey]` — a default suggestion, not an override
+3. `entry.defaultSize` — final fallback
+
+The size pref's `value` in `PREFS_CONFIG` is `""` (empty string). Empty means
+"the user has not chosen a size", which is what lets the trainhop suggestion and
+`defaultSize` apply. Once the user resizes, the pref holds a real value and wins.
+Never read the size pref directly in a component — go through `resolveWidgetSize`.
+
+(Weather is the one exception: its size pref uses `getValue: getWeatherWidgetSize`
+in `ActivityStream.sys.mjs` for a one-time migration from the old weather config.)
 
 ## Build order matters
 
-Generate and register the prefs in `ActivityStream.sys.mjs` **first**, then
-run `./mach build faster` before scaffolding the remaining files. The enablement
-logic in `Widgets.jsx` reads prefs from the Redux store — if they aren't
-registered by the build yet, the widget won't appear even when Nimbus/trainhop
-is configured.
+Register the prefs in `ActivityStream.sys.mjs` **first**, then run
+`./mach build faster` before scaffolding the rest. The container reads prefs from
+the Redux store — if they aren't registered by the build yet, the widget won't
+appear even when Nimbus/trainhop is configured.
 
-## SCSS must be imported in BOTH stylesheets
+## `./mach newtab bundle` is required for SCSS/JSX changes
 
-There are two activity-stream SCSS entry points:
+`./mach build faster` only copies already-compiled files to the build output. It
+does **not** recompile SCSS or JS. After any SCSS or JSX change:
 
-1. `content-src/styles/activity-stream.scss` — classic layout
-2. `content-src/styles/nova/activity-stream.scss` — Nova layout
-
-**You must add the `@import` to both files.** If you only add it to one,
-the widget will have zero styles in the other layout mode. Nova is the
-active layout for most users, so missing the Nova import means the widget
-renders completely unstyled.
-
-## `./mach newtab bundle` is required for SCSS changes
-
-`./mach build faster` only copies already-compiled files to the build output.
-It does **not** recompile SCSS or JS. After any SCSS or JSX change:
-
-1. Run `./mach newtab bundle` to compile
-2. Run `./mach build faster` to copy to the build output
+1. `./mach newtab bundle` — compile
+2. `./mach build faster` — copy to the build output
 3. Reload `about:newtab`
 
 The compiled artifacts (`css/activity-stream.css`, `css/nova/activity-stream.css`,
 `data/content/activity-stream.bundle.js`) are checked into the repo and must be
 committed after bundling.
 
+## SCSS @import and the stylelint rollout list
+
+Add the widget's `_{Name}.scss` `@import` to
+`content-src/styles/activity-stream.scss`. (`styles/nova/activity-stream.scss`
+still exists for the CSS-switcher path but the main entry point is what matters
+for new widgets.) Then add the SCSS file path to `stylelint-rollouts.config.js`
+at the repo root, in alphabetical order alongside the other widget entries.
+
+Nova-specific CSS must be scoped under `.nova-enabled`.
+
 ## `widgets.system.enabled` is the parent gate
 
 The entire widgets section (customize panel, about:preferences, and the widget
-container on the new tab page) is gated by `widgets.system.enabled`, which
-defaults to `false`. Even with all per-widget prefs set correctly, nothing
-appears unless this parent gate is enabled via `about:config` or a Nimbus
-experiment.
+container) is gated by `widgets.system.enabled`, which defaults to `false`. Even
+with all per-widget prefs set, nothing appears unless this parent gate is enabled
+via `about:config` or a Nimbus experiment. Always include it in enable instructions.
 
-## Base.jsx has TWO CustomizeMenu renders
+## Customize panel toggle (Base.jsx + CustomizeMenu + WidgetsManagementPanel)
 
-`Base.jsx` renders `<CustomizeMenu>` in **two separate locations** (for
-different layout modes). You must add the `mayHave{Name}Widget` prop to
-**both** JSX blocks. If you only add it to one, the customize panel toggle
-silently won't appear in the other layout.
+The toggle in the customize panel requires edits in a chain — miss one and the
+toggle silently never appears:
 
-Search for `mayHaveListsWidget={` in Base.jsx — you should see two matches.
-Add your new prop next to both.
+1. `Base.jsx` — compute `mayHave{Name}Widget` (mirror an existing widget such as
+   `mayHaveListsWidget`) and pass it to **both** `<CustomizeMenu>` renders.
+   `Base.jsx` renders `<CustomizeMenu>` in two places (different layout modes) —
+   search for `mayHaveListsWidget={` to find both.
+2. `content-src/components/CustomizeMenu/CustomizeMenu.jsx` — forward the prop
+   (required passthrough).
+3. `content-src/components/Nova/CustomizeMenu/WidgetsManagementPanel/WidgetsManagementPanel.jsx`
+   — add a `moz-toggle` block. This is now a functional component; mirror an
+   existing widget's section (it sets `data-preference="widgets.{key}.enabled"`,
+   `data-event-source`, and `data-l10n-id`).
+4. `ContentSection.jsx` — the classic-layout path.
+5. `browser/locales/en-US/browser/newtab/newtab.ftl` — the toggle label
+   (`newtab-custom-widget-{css-class}-toggle`).
 
-## CustomizeMenu.jsx is a required passthrough
+When in doubt, grep an existing widget's key (e.g. `lists`, `weather`) across
+these files and replicate every hit.
 
-`Base.jsx` passes `mayHave*Widget` props to `<CustomizeMenu>`, which forwards
-them to `<ContentSection>`. If you add the prop in `Base.jsx` and `ContentSection.jsx`
-but forget `CustomizeMenu.jsx`, the toggle silently never appears.
+## about:preferences registration
 
-Files to touch for the Customize panel toggle (all four are required):
-
-1. `Base.jsx` — compute `mayHave{Name}Widget` and `{widgetKey}Enabled`
-2. `CustomizeMenu.jsx` — forward the prop
-3. `ContentSection.jsx` — add the `switch` case and render the `moz-toggle`
-4. `browser/locales/en-US/browser/newtab/newtab.ftl` — add the toggle label string
-
-## AboutPreferences.sys.mjs registration
-
-Widgets must be registered in `AboutPreferences.sys.mjs` to appear in
-`about:preferences > Home`. Three changes are needed in this file:
-
-**1. Pref definitions** (in the `preferences` array near the top):
-```js
-{
-  id: "browser.newtabpage.activity-stream.widgets.system.{widgetKey}.enabled",
-  type: "bool",
-},
-{
-  id: "browser.newtabpage.activity-stream.widgets.{widgetKey}.enabled",
-  type: "bool",
-},
-```
-
-**2. Settings** (in `_setupHomeGroup`):
-```js
-Preferences.addSetting({
-  id: "{widgetKey}Enabled",
-  pref: "browser.newtabpage.activity-stream.widgets.system.{widgetKey}.enabled",
-});
-
-Preferences.addSetting({
-  id: "{widgetKey}",
-  pref: "browser.newtabpage.activity-stream.widgets.{widgetKey}.enabled",
-  deps: ["{widgetKey}Enabled"],
-  visible: ({ {widgetKey}Enabled }) => {widgetKey}Enabled.value,
-});
-```
-
-**3. Items array** (add to the `widgets` section's `items`):
-```js
-{
-  id: "{widgetKey}",
-  l10nId: "home-prefs-{css-class}-header",
-},
-```
-
-**4. FTL string** in `browser/locales/en-US/browser/preferences/preferences.ftl`:
-```ftl
-home-prefs-{css-class}-header =
-    .label = {Display Name}
-```
+Register the widget in `lib/AboutPreferences.sys.mjs` so it appears under
+`about:preferences#home`, and add a `home-prefs-{css-class}-header` string to
+`browser/locales/en-US/browser/preferences/preferences.ftl`. The exact shape of
+the entries in this file evolves — mirror an existing widget (weather or lists)
+rather than copying a fixed snippet.
 
 ## FTL file locations and string formats
 
-Widget strings live in **two separate FTL files**:
+Widget strings live in two FTL files:
 
 - `browser/locales/en-US/browser/newtab/newtab.ftl` — new tab page strings
-- `browser/locales/en-US/browser/preferences/preferences.ftl` — about:preferences strings
+  (the bundled copy lives under `webext-glue/locales/...`, but author in the
+  source `browser/locales/...` file)
+- `browser/locales/en-US/browser/preferences/preferences.ftl` — about:preferences
 
-Add a `##` group comment only at the start of the section, not at the end.
-A `##` with no messages after it is a lint error (GC04).
+Shared strings already exist — reuse them, do not redefine:
+`newtab-widget-menu-hide`, `newtab-widget-menu-change-size`,
+`newtab-widget-menu-move`, `newtab-widget-menu-move-left`,
+`newtab-widget-menu-move-right`, `newtab-widget-size-small`/`-medium`/`-large`.
 
 String formats differ by type — do not mix them up:
 
-**Customize panel toggle** — uses `.label` attribute:
-
+**Customize panel toggle** — uses `.label`:
 ```ftl
 newtab-custom-widget-{css-class}-toggle =
     .label = {Display Name}
 ```
 
-**Context menu Learn More** — plain string, no attribute:
-
+**about:preferences header** — uses `.label`:
 ```ftl
-newtab-{css-class}-widget-menu-learn-more = Learn more
+home-prefs-{css-class}-header =
+    .label = {Display Name}
 ```
 
-**Context menu Hide** — shared string, already exists, do not add it:
-
+**Context menu Learn More** — plain string:
 ```ftl
-newtab-widget-menu-hide = Hide
+newtab-{css-class}-menu-learn-more = Learn more
 ```
+
+Add a `##` group comment only at the start of a section, never trailing. A `##`
+with no messages after it is a lint error (GC04).
+
+Never invent user-facing string values — copy comes from a copywriter. Wait for
+the literal text before adding the message.
+
+## Widget resize context menu — use the useSizeSubmenu hook
+
+The resize submenu is a `<panel-item submenu>` containing a `<panel-list>` of
+size `<panel-item type="checkbox">` rows. Wire its clicks with the shared
+`useSizeSubmenu(handleChangeSize)` hook from `content-src/lib/utils`:
+
+```jsx
+const sizeSubmenuRef = useSizeSubmenu(handleChangeSize);
+// ...
+<panel-list ref={sizeSubmenuRef} slot="submenu" id="{css-class}-size-submenu">
+```
+
+Do NOT hand-roll a `useEffect` + `composedPath()` click listener — that's exactly
+what the hook now encapsulates. React's synthetic `onClick` does not cross the
+`panel-list` shadow-DOM boundary, which is why the hook listens at the root.
+
+Gate the submenu on `widgetsMayBeMaximized`. Build the size list from the entry's
+`validSizes` — include `"small"` only when it is present.
+
+## Widget reorder — the MoveSubmenu component
+
+Widgets can be reordered. Render the shared component in the context menu, before
+Hide/Learn more:
+
+```jsx
+import { MoveSubmenu } from "../MoveSubmenu";
+// ...
+<MoveSubmenu widgetId="{key}" widgetEnabledMap={widgetEnabledMap} />
+```
+
+It reads/writes the `widgets.order` pref via `resolveWidgetOrder`, renders nothing
+when the widget can't move, and (like the size submenu) listens at the panel-list
+root for `data-move-dir` clicks. You don't write any order logic yourself.
+
+## Standard widget props
+
+Row widgets receive: `dispatch`, `handleUserInteraction`, `isMaximized`,
+`widgetsMayBeMaximized`, and `widgetEnabledMap` (a map of `id → boolean` for which
+widgets are currently active — used by `MoveSubmenu` and any cross-widget checks).
+A widget that takes its size from a row-wrapper (see sidebar variant) also receives
+a `size` prop. Omit `handleUserInteraction` for view-only widgets.
+
+## WidgetWrapper is a container concern
+
+`Widgets/WidgetWrapper.jsx` applies `widget-wrapper col-4` and drag-and-drop
+plumbing. The container wraps widgets with it — the widget component renders its
+own `<article className="{css} widget col-4 ${size}-widget">` and does not import
+WidgetWrapper itself.
+
+## Trainhop key namespace
+
+Trainhop overrides are read from `trainhopConfig.widgets.*` using the keys named
+in the registry entry: `trainhopEnabledKey`, `trainhopSizeKey`, and
+`trainhopSidebarKey`. The convention is camelCase id + suffix
+(`{key}Enabled`, `{key}Size`, `{key}Sidebar`). The registry helpers already read
+these — you only declare the keys on the entry.
+
+## Sidebar variant (optional)
+
+Widgets can render in the sidebar at size `"small"` via `hasSidebar: true` plus a
+component in `WIDGET_SIDEBAR_COMPONENTS` (Weather is the only one today). This is
+not part of the default scaffold. When a spec needs it, see
+[`SidebarVariant.md`](./SidebarVariant.md) for the registry fields and the
+row-wrapper / sidebar-component split.
+
+## hide-all is registry-derived
+
+"Hide all widgets" is driven by `getHideAllTargets(prefs, widgetEnabledMap)` and
+the `WIDGETS_HIDE_ALL` action — you do not edit a hand-maintained list of
+`SetPref` dispatches anymore. Adding a registry entry automatically includes the
+widget. (The legacy per-widget `hideAllWidgets` test-count assertions no longer
+apply.)
 
 ## Action types must be alphabetically sorted
 
-The action types array in `common/Actions.mjs` is alphabetically sorted, and
-there is an existing test that asserts this ordering. If you add new action
-types out of alphabetical order, that test will fail. For example,
-`WIDGETS_WORD_OF_THE_DAY_SEEN` must come before `WIDGETS_WORD_OF_THE_DAY_SET`.
-
-## Existing hideAllWidgets tests will break
-
-Adding a new `dispatch(ac.SetPref(...))` call to `hideAllWidgets()` in
-`Widgets.jsx` changes the number of `SetPref` dispatches. The existing tests
-in `test/unit/content-src/components/Widgets.test.jsx` assert the exact count.
-Update the expected count and assertion messages in these tests:
-
-- "should dispatch SetPref actions when hide button is clicked"
-- "should dispatch SetPref actions when Enter key is pressed on hide button"
-- "should dispatch SetPref actions when Space key is pressed on hide button"
-
-## Use `.jsx` extension for content-src data files
-
-Files in `content-src/` must use the `.jsx` extension, not `.js`. The ESLint
-config only treats `test/**/*.js` files as ES modules. A `.js` file in
-`content-src/` will fail with: `Parsing error: 'import' and 'export' may
-appear only with 'sourceType: module'`.
-
-## handleUserInteraction is conditional
-
-Only include `handleUserInteraction` in the component signature and call it if
-the widget has body interactions (Q5 = yes). For view-only widgets, omit it
-from both the destructure and the JSX props in `Widgets.jsx`.
+The action types in `common/Actions.mjs` are alphabetically sorted, and a test in
+`test/unit/common/Actions.test.js` asserts it. Only relevant if your widget needs
+new `WIDGETS_*` action types (most don't). Keep them in order, e.g.
+`WIDGETS_..._SEEN` before `WIDGETS_..._SET`.
 
 ## batch() on every multi-dispatch
 
-Any handler that dispatches two or more actions must wrap them in `batch()`
-to avoid intermediate renders. This includes `handleHide`, user event handlers,
-and any action that pairs a state change with a telemetry dispatch.
-
-## Nimbus trainhop naming convention
-
-The trainhop key follows camelCase + "Enabled" suffix:
-
-- `prefs.trainhopConfig?.widgets?.{widgetKey}Enabled`
-
-Match this exactly — a typo here means the Nimbus experiment path silently
-does nothing.
-
-## Full enabled logic blocks (Widgets.jsx and Base.jsx)
-
-These two patterns are not visible from the ExampleWidget component file alone.
-
-**Widgets.jsx** — pref constants and enabled expression to add alongside existing widgets:
-
-```js
-const PREF_WIDGETS_{WIDGET_KEY}_ENABLED = "widgets.{widgetKey}.enabled";
-const PREF_WIDGETS_SYSTEM_{WIDGET_KEY}_ENABLED = "widgets.system.{widgetKey}.enabled";
-```
-
-```js
-const nimbus{ComponentName}TrainhopEnabled =
-  prefs.trainhopConfig?.widgets?.{widgetKey}Enabled;
-const {widgetKey}Enabled =
-  (nimbus{ComponentName}TrainhopEnabled ||
-    prefs[PREF_WIDGETS_SYSTEM_{WIDGET_KEY}_ENABLED]) &&
-  prefs[PREF_WIDGETS_{WIDGET_KEY}_ENABLED];
-```
-
-**Base.jsx** — nimbus variables and `mayHave` flag to add alongside existing widgets:
-
-```js
-const nimbus{ComponentName}Enabled = prefs.widgetsConfig?.{widgetKey}Enabled;
-const nimbus{ComponentName}TrainhopEnabled =
-  prefs.trainhopConfig?.widgets?.{widgetKey}Enabled;
-const mayHave{ComponentName}Widget =
-  prefs["widgets.system.{widgetKey}.enabled"] ||
-  nimbus{ComponentName}Enabled ||
-  nimbus{ComponentName}TrainhopEnabled;
-```
-
-Also add `{widgetKey}Enabled: prefs["widgets.{widgetKey}.enabled"]` to the
-`enabledWidgets` object in `Base.jsx`, and pass `mayHave{ComponentName}Widget`
-as a prop to **both** `<CustomizeMenu>` renders.
-
-**Widget component itself** — only needed when the component has its own
-`return null` guard (i.e. special enable conditions from Q9). Read the trainhop
-variable directly from prefs inside the component, mirroring `WeatherForecast.jsx`:
-
-```js
-const nimbus{ComponentName}TrainhopEnabled =
-  prefs.trainhopConfig?.widgets?.{widgetKey}Enabled;
-const {widgetKey}WidgetEnabled =
-  nimbus{ComponentName}TrainhopEnabled ||
-  prefs["widgets.system.{widgetKey}.enabled"];
-
-if (!{widgetKey}WidgetEnabled || /* other special conditions */) {
-  return null;
-}
-```
-
-For standard widgets without special conditions, skip this — the guard lives
-entirely in `Widgets.jsx` and the component always renders when mounted.
+Any handler that dispatches two or more actions must wrap them in `batch()` to
+avoid intermediate renders — hide handlers, resize, user events that pair a state
+change with a telemetry dispatch, etc.
 
 ## Learn More URL
 
-Always point to: `https://support.mozilla.org/kb/firefox-new-tab-widgets`
+Always point to `https://support.mozilla.org/kb/firefox-new-tab-widgets`. Do not
+create a widget-specific SUMO page — all widgets share this URL.
 
-Do not create a widget-specific SUMO page — all widgets share this URL.
+## Use the `.jsx` extension for content-src files
 
-## null guard in Widgets.jsx
-
-The `if (!(listsEnabled || timerEnabled || ...))` guard controls whether the
-entire widget section renders. Add your new `{widgetKey}Enabled` to this OR
-expression, otherwise hiding all other widgets will leave your widget orphaned
-in an empty container.
-
-## `_Widgets.scss` `:has()` selector
-
-The `.widgets-container` rule uses `:has(.lists), :has(.focus-timer)` to apply
-layout when any widget is present. Add your widget's CSS class to this selector
-or the container layout won't activate when only your widget is visible.
-
-## Toast string (pending)
-
-`newtab-toast-widgets-hidden` is not yet landed. Once it lands and we rebase,
-wire it up to the hide action in the individual widget's hide handler.
+Files in `content-src/` must use `.jsx`, not `.js`. The ESLint config only treats
+`test/**/*.js` as ES modules; a `.js` file in `content-src/` fails with
+`Parsing error: 'import' and 'export' may appear only with 'sourceType: module'`.
 
 ## Redux state (optional)
 
-Only add a Redux slice if the widget needs cross-tab persistence or complex
-shared state. Simple local state (`useState`) is preferable for transient UI.
-When in doubt, don't add Redux — it can always be added later.
+Only add a Redux slice if the widget needs cross-tab persistence or complex shared
+state. Simple local state (`useState`) is preferable for transient UI. When in
+doubt, don't add Redux — it can be added later.
 
-## Widget sizes and supportsSmallSize
+## Tests go in Jest
 
-The size pref always supports `"medium"` and `"large"`. If the spec's
-`supportsSmallSize` is `yes`, `"small"` is also valid and must be included
-in the context menu and the size derivation logic.
-
-The default size is `"medium"` — use it as the fallback when the pref is not
-yet set. See `references/ExampleWidget/ExampleWidget.jsx` for the full size
-derivation block and the resize context menu with `hidden` attributes.
-
-## about:preferences registration
-
-Every widget must be registered in `AboutPreferences.sys.mjs` and have a
-corresponding FTL string in
-`browser/locales/en-US/browser/preferences/preferences.ftl` for its toggle
-to appear in `about:preferences`.
-
-## Parent gate pref
-
-The pref `browser.newtabpage.activity-stream.widgets.system.enabled` is a
-parent gate for all widgets and defaults to `false`. It must be set to `true`
-alongside the widget-specific prefs for the widget to appear. Always include
-it in enable instructions.
-
-## Widget resize context menu
-
-Every widget has a resize submenu. Use the `handleChangeSize` / `sizeSubmenuRef`
-/ `useEffect` pattern shown in `ExampleWidget.jsx` — do NOT use separate
-`<panel-item hidden={...}>` elements. React's synthetic `onClick` does not
-traverse the shadow DOM boundary on `panel-list`, so the hidden-item pattern
-silently does nothing.
-
-The submenu uses the shared strings `newtab-widget-size-medium`,
-`newtab-widget-size-large`, and (if `supportsSmallSize = yes`)
-`newtab-widget-size-small` — do not add widget-specific resize FTL strings.
-
-## Nova layout: JSX patterns
-
-Every widget must read `nova.enabled` and apply Nova-specific classes and size
-logic. All Nova conditionals are temporary and marked for cleanup when Nova ships.
-
-Add at the top of the component file:
-
-```js
-const PREF_NOVA_ENABLED = "nova.enabled";
-const PREF_{WIDGET_KEY}_SIZE = "widgets.{widgetKey}.size";
-```
-
-Inside the component function, add size derivation:
-
-```js
-// @nova-cleanup(remove-pref): Remove novaEnabled and this check; always use prefs[PREF_{WIDGET_KEY}_SIZE] directly after Nova ships
-const novaEnabled = prefs[PREF_NOVA_ENABLED];
-const isSmallSize = novaEnabled
-  ? prefs[PREF_{WIDGET_KEY}_SIZE] === "small"
-  : <classic-size-logic>;
-let widgetSize;
-if (novaEnabled) {
-  // Default is "medium". If spec supportsSmallSize = yes, "small" is also valid.
-  widgetSize = prefs[PREF_{WIDGET_KEY}_SIZE] || "medium";
-} else {
-  widgetSize = isSmallSize ? "small" : "medium";
-}
-```
-
-On the root element's className:
-
-```jsx
-// @nova-cleanup(remove-conditional): Remove novaEnabled check; always apply col-4 and size class after Nova ships
-className={`{css-class} widget ${novaEnabled ? `col-4 ${widgetSize}-widget` : ""} ${isSmallSize ? "is-small" : ""}`}
-```
-
-## Nova layout: SCSS patterns
-
-Classic-specific styles (fixed widths, heights) go inside `.classic-enabled &`
-with a `@nova-cleanup(remove-conditional)` comment — see `_ExampleWidget.scss`
-for the pattern.
-
-If the widget needs to declare its own `grid-column` span within the Nova
-subgrid, use `.nova-enabled &`:
-
-```scss
-// @nova-cleanup(remove-conditional): Make default, remove .nova-enabled selector
-.nova-enabled & {
-  grid-column: span 4;
-}
-```
+New per-widget tests live in `test/jest/content-src/components/Widgets/{Name}.test.jsx`
+(React Testing Library + `expect()`), alongside `SportsWidget.test.jsx`,
+`Weather.test.jsx`, etc. There is also a `WidgetsRegistry.test.jsx` for
+registry-level coverage. The legacy `test/unit/` Enzyme suite still exists, but
+add new tests to Jest unless extending an existing Enzyme file.

--- a/plugins/newtab/skills/widgets-scaffold/scripts/gather_requirements.py
+++ b/plugins/newtab/skills/widgets-scaffold/scripts/gather_requirements.py
@@ -3,7 +3,8 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-"""Gather widget requirements interactively and print a spec summary for Claude."""
+"""Gather widget requirements interactively and print a spec + WIDGET_REGISTRY
+entry for Claude."""
 
 import re
 import sys
@@ -33,6 +34,44 @@ def to_upper_snake(camel):
     return to_snake(camel).upper()
 
 
+def strip_widget(value):
+    """Remove a redundant 'widget' token from a name. The pref namespace is
+    already `widgets.`, so a *Widget suffix duplicates it (this caused a real
+    pref/telemetry bug on the Sports widget). Returns the cleaned value."""
+    # camelCase / PascalCase suffix: fooWidget -> foo
+    cleaned = re.sub(r"[Ww]idget", "", value)
+    # snake/kebab leftovers: foo_widget / foo- -> foo
+    cleaned = re.sub(r"[_-]+$", "", cleaned)
+    cleaned = re.sub(r"^[_-]+", "", cleaned)
+    return cleaned
+
+
+def ask_clean_name(prompt, label):
+    """Ask for a name and refuse a 'widget' token (with a suggested fix)."""
+    while True:
+        value = ask(prompt)
+        if "widget" not in value.lower():
+            return value
+        suggestion = strip_widget(value)
+        print(
+            f"\n  '{value}' contains 'widget'. The {label} must NOT include it — "
+            f"it lives under the `widgets.` namespace, so the suffix is redundant\n"
+            f"  (this caused a pref/telemetry bug on the Sports widget)."
+        )
+        choice = input(
+            f"> Use '{suggestion}' instead? [Enter = yes, or type another value]: "
+        ).strip()
+        if not choice:
+            if suggestion:
+                return suggestion
+            print("  Cannot derive a clean name — please type one.")
+            continue
+        if "widget" in choice.lower():
+            print("  That still contains 'widget'. Try again.")
+            continue
+        return choice
+
+
 def main():
     print("=" * 60)
     print("New Tab Widget Requirements Gatherer")
@@ -41,18 +80,22 @@ def main():
 
     # Q1
     display_name = ask(
-        "Q1. What is the human-readable display name of the widget?\n    (e.g. 'Reading List', 'Quick Notes')"
+        "Q1. What is the human-readable display name of the widget?\n"
+        "    (e.g. 'Reading List', 'Quick Notes')"
     )
 
-    # Q2
-    widget_key = ask(
-        "Q2. What is the camelCase key for this widget?\n    (e.g. 'readingList', 'quickNotes') — used in pref names and telemetry"
+    # Q2 — enforce no "widget" suffix
+    widget_key = ask_clean_name(
+        "Q2. What is the camelCase key (registry `id`) for this widget?\n"
+        "    (e.g. 'readingList', 'quickNotes') — used in pref names and the order pref.\n"
+        "    Do NOT include 'widget' (use 'sports', not 'sportsWidget').",
+        "widget id",
     )
 
-    # Q3 — inferred
+    # Q3 — css class inferred
     css_class = to_kebab(widget_key)
     print(
-        f"\n[Q3 inferred] CSS class: '{css_class}'  (derived from camelCase key — override below if needed)"
+        f"\n[Q3 inferred] CSS class: '{css_class}'  (derived from the key — override below if needed)"
     )
     override = input(
         f"> Press Enter to accept '{css_class}', or type a different value: "
@@ -61,80 +104,171 @@ def main():
         css_class = override
 
     component_name = widget_key[0].upper() + widget_key[1:]
-    telemetry_name = to_snake(widget_key)
     widget_key_upper = to_upper_snake(widget_key)
 
-    # Q4
+    # Q4 — telemetry name (snake_case), also enforced clean
+    default_telemetry = to_snake(widget_key)
+    print(
+        f"\n[Q4 inferred] telemetryName: '{default_telemetry}'  (snake_case Glean name)"
+    )
+    tel_override = input(
+        f"> Press Enter to accept '{default_telemetry}', or type a different value: "
+    ).strip()
+    telemetry_name = tel_override or default_telemetry
+    if "widget" in telemetry_name.lower():
+        fixed = strip_widget(telemetry_name) or default_telemetry
+        print(
+            f"  telemetryName must not include 'widget' — using '{fixed}' "
+            f"(Sports had to fix 'sports_widget' -> 'sports')."
+        )
+        telemetry_name = fixed
+
+    # Q5 — order
+    order = ask(
+        "Q5. What `order` integer should this widget have?\n"
+        "    (0-indexed render position; use the next free integer after the\n"
+        "     existing entries, or 'next' to let Claude fill it in.)",
+        allow_empty=True,
+    ) or "next"
+
+    # Q6 — valid sizes
+    sizes_raw = ask(
+        "Q6. Which sizes does this widget support?\n"
+        "    Comma-separated subset of: small, medium, large (e.g. 'medium, large')."
+    )
+    valid_sizes = [
+        s.strip().lower()
+        for s in sizes_raw.split(",")
+        if s.strip().lower() in ("small", "medium", "large")
+    ] or ["medium", "large"]
+    # keep canonical order
+    valid_sizes = [s for s in ("small", "medium", "large") if s in valid_sizes]
+
+    # Q7 — default size
+    default_size = ask(
+        f"Q7. What is the default size when the user hasn't chosen one?\n"
+        f"    One of {valid_sizes} (default 'medium').",
+        allow_empty=True,
+    ).lower()
+    if default_size not in valid_sizes:
+        default_size = "medium" if "medium" in valid_sizes else valid_sizes[0]
+
+    # Q8 — sidebar variant (only meaningful when "small" is supported)
+    has_sidebar = False
+    if "small" in valid_sizes:
+        sidebar_raw = ask(
+            "Q8. Should this widget move to the SIDEBAR when its size is 'small'?\n"
+            "    Most widgets stay in the row — answer 'no' unless the spec needs a\n"
+            "    sidebar placement (only Weather does today). Answer 'yes' or 'no'."
+        )
+        has_sidebar = sidebar_raw.lower().startswith("y")
+    else:
+        print("\n[Q8 skipped] No 'small' size, so no sidebar variant.")
+
+    # Q9
     extra_menu_items = ask(
-        "Q4. Any extra context menu items beyond 'Hide' and 'Learn More'?\n"
+        "Q9. Any extra context menu items beyond 'Hide', 'Learn More', resize, and move?\n"
         "    List them (e.g. 'Change Location, Toggle Unit') or type 'none'.",
         allow_empty=True,
     )
 
-    # Q5
+    # Q10
     interactive_raw = ask(
-        "Q5. Will users interact with the widget body itself (clicking buttons, typing, etc.)?\n"
-        "    Or is it view-only? Answer 'yes' (interactive) or 'no' (view-only)."
+        "Q10. Will users interact with the widget body itself (clicking buttons, typing, etc.)?\n"
+        "     Or is it view-only? Answer 'yes' (interactive) or 'no' (view-only)."
     )
     is_interactive = interactive_raw.lower().startswith("y")
 
-    # Q6 — conditional
+    # Q11 — conditional
     user_actions = ""
     if is_interactive:
         user_actions = ask(
-            "Q6. What are the user action type strings for body interactions?\n"
-            "    (e.g. 'add_item, toggle_item, delete_item')"
+            "Q11. What are the user action type strings for body interactions?\n"
+            "     (e.g. 'add_item, toggle_item, delete_item')"
         )
 
-    # Q7
+    # Q12
     extra_prefs = ask(
-        "Q7. Any widget-specific prefs beyond 'enabled' / 'system.enabled'?\n"
-        "    List each with type and default (e.g. 'widgets.readingList.maxItems, int, 20') or 'none'.",
+        "Q12. Any widget-specific prefs beyond enabled / system.enabled / size?\n"
+        "     List each with type and default (e.g. 'widgets.readingList.maxItems, int, 20') or 'none'.",
         allow_empty=True,
     )
 
-    # Q8
+    # Q13
     redux_state_raw = ask(
-        "Q8. Does this widget need its own Redux state slice?\n"
-        "    'yes' + brief shape description, or 'no'."
+        "Q13. Does this widget need its own Redux state slice?\n"
+        "     'yes' + brief shape description, or 'no'."
     )
     has_redux = redux_state_raw.lower().startswith("y")
     redux_shape = redux_state_raw[3:].strip() if has_redux else ""
 
-    # Q9
+    # Q14
     special_conditions = ask(
-        "Q9. Any special enable conditions beyond 'enabled' + 'system.enabled'?\n"
-        "    Describe them, or type 'none'.",
+        "Q14. Any special enable conditions beyond enabled + system.enabled\n"
+        "     (e.g. needs a backend feed, depends on geolocation)? Describe or 'none'.",
         allow_empty=True,
     )
 
-    # Q10
-    supports_small_size_raw = ask(
-        "Q10. Does this widget support a small size in addition to medium and large?\n"
-        "     Answer 'yes' or 'no'."
-    )
-    supports_small_size = supports_small_size_raw.lower().startswith("y")
+    trainhop_enabled = f"{widget_key}Enabled"
+    trainhop_size = f"{widget_key}Size"
+    trainhop_sidebar = f"{widget_key}Sidebar" if has_sidebar else "null"
+    sidebar_key_literal = f'"{trainhop_sidebar}"' if has_sidebar else "null"
 
     # --- Print summary ---
     print("\n" + "=" * 60)
     print("WIDGET SPEC — hand this to Claude to enter plan mode")
     print("=" * 60)
-    print(f"  displayName:    {display_name}")
-    print(f"  componentName:  {component_name}")
-    print(f"  widgetKey:      {widget_key}")
-    print(f"  cssClass:       {css_class}")
-    print(f"  telemetryName:  {telemetry_name}")
-    print(f"  WIDGET_KEY:     {widget_key_upper}")
-    print(f"  interactive:    {'yes' if is_interactive else 'no (view-only)'}")
+    print(f"  displayName:       {display_name}")
+    print(f"  componentName:     {component_name}")
+    print(f"  widgetKey (id):    {widget_key}")
+    print(f"  cssClass:          {css_class}")
+    print(f"  telemetryName:     {telemetry_name}")
+    print(f"  WIDGET_KEY:        {widget_key_upper}")
+    print(f"  order:             {order}")
+    print(f"  validSizes:        {valid_sizes}")
+    print(f"  defaultSize:       {default_size}")
+    print(f"  hasSidebar:        {'yes' if has_sidebar else 'no'}")
+    print(f"  interactive:       {'yes' if is_interactive else 'no (view-only)'}")
     if is_interactive and user_actions:
-        print(f"  userActions:    {user_actions}")
-    print(f"  extraMenuItems: {extra_menu_items or 'none'}")
-    print(f"  extraPrefs:     {extra_prefs or 'none'}")
-    print(f"  reduxState:     {'yes — ' + redux_shape if has_redux else 'no'}")
+        print(f"  userActions:       {user_actions}")
+    print(f"  extraMenuItems:    {extra_menu_items or 'none'}")
+    print(f"  extraPrefs:        {extra_prefs or 'none'}")
+    print(f"  reduxState:        {'yes — ' + redux_shape if has_redux else 'no'}")
     print(f"  specialConditions: {special_conditions or 'none'}")
-    print(f"  supportsSmallSize: {'yes' if supports_small_size else 'no'}")
+
+    print("\n" + "-" * 60)
+    print("WIDGET_REGISTRY entry (add to common/WidgetsRegistry.mjs):")
+    print("-" * 60)
+    valid_sizes_js = ", ".join(f'"{s}"' for s in valid_sizes)
+    print(
+        f"""  {{
+    id: "{widget_key}",
+    telemetryName: "{telemetry_name}",
+    order: {order if order != 'next' else '/* next free integer */'},
+    enabledPref: PREF_WIDGETS_{widget_key_upper}_ENABLED,
+    sizePref: PREF_{widget_key_upper}_SIZE,
+    defaultSize: "{default_size}",
+    validSizes: [{valid_sizes_js}],
+    hasSidebar: {'true' if has_sidebar else 'false'},
+    systemEnabledPref: PREF_WIDGETS_SYSTEM_{widget_key_upper}_ENABLED,
+    trainhopEnabledKey: "{trainhop_enabled}",
+    trainhopSizeKey: "{trainhop_size}",
+    trainhopSidebarKey: {sidebar_key_literal},
+  }},"""
+    )
+    print("\n  Pref-key constants to export from the same file:")
+    print(
+        f'    export const PREF_WIDGETS_{widget_key_upper}_ENABLED = "widgets.{widget_key}.enabled";\n'
+        f'    export const PREF_{widget_key_upper}_SIZE = "widgets.{widget_key}.size";\n'
+        f'    export const PREF_WIDGETS_SYSTEM_{widget_key_upper}_ENABLED = "widgets.system.{widget_key}.enabled";'
+    )
+    if has_sidebar:
+        print(
+            "\n  hasSidebar: true — also register a sidebar component. "
+            "See references/SidebarVariant.md."
+        )
     print("=" * 60)
-    print("\nNow enter plan mode: /newtab-widget-scaffold with the spec above.")
+    print("\nNow enter plan mode: /widgets-scaffold with the spec above.")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The skill predated the Widget Registry refactor and taught an obsolete, error-prone workflow (hand-wiring enabled-logic, size derivation, hide-all, and null-guards into Widgets.jsx/Base.jsx). Rework all artifacts around the registry as the source of truth.

- SKILL.md: registry-centric workflow — a WIDGET_REGISTRY entry + WIDGET_ROW_COMPONENTS entry + prefs, then supporting files. Drop the hand-wired container logic and the per-widget Nova gate.
- notes.md: reconcile the contradictory Nova section (gating is container-level, not per-widget), replace hand-wired logic with the registry helpers, and add reorder/MoveSubmenu, useSizeSubmenu, WidgetWrapper, trainhop key namespace, and the naming convention.
- ExampleWidget: model the current pattern (resolveWidgetSize, useSizeSubmenu, MoveSubmenu, standard props, clean naming, no per-widget Nova gate).
- SidebarVariant.md: new focused snippet for the optional sidebar wiring.
- gather_requirements.py: collect registry fields, emit a ready-to-paste WIDGET_REGISTRY entry, and enforce the no-"widget"-suffix naming rule.
