### PR TITLE
newtab/widgets-scaffold: document widgetEnabledMap step

### DIFF
--- a/plugins/newtab/.claude-plugin/plugin.json
+++ b/plugins/newtab/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "newtab",
   "description": "Skills and tools for Firefox Home/New Tab development",
-  "version": "1.0.1"
+  "version": "1.0.2"
 }

--- a/plugins/newtab/skills/widgets-scaffold/SKILL.md
+++ b/plugins/newtab/skills/widgets-scaffold/SKILL.md
@@ -91,8 +91,12 @@ The registry-centric core (do these first, in order):
 
 The supporting files (each widget still touches these):
 
-6. `Widgets/{Name}/_{Name}.scss` — styles. Add `&.medium-widget { grid-row: span 2; }`
-   and `&.large-widget { grid-row: span 4; }` inside the root class; add
+6. `Widgets/{Name}/_{Name}.scss` — styles. `@include widget-base-style` on the
+   root (NOT `newtab-card-style`): it provides the shared per-size card height,
+   hover, transitions, and `position: relative`. Including `newtab-card-style`
+   directly leaves the card with no height, so a sparse or not-yet-wired widget
+   body collapses. Add `&.medium-widget { grid-row: span 2; }` and
+   `&.large-widget { grid-row: span 4; }` inside the root class; add
    `&.small-widget { grid-row: span 1; }` only if `validSizes` includes `"small"`.
 7. `content-src/styles/activity-stream.scss` — add `@import` of the widget SCSS.
 8. `stylelint-rollouts.config.js` (repo root) — add the SCSS path in alphabetical

--- a/plugins/newtab/skills/widgets-scaffold/SKILL.md
+++ b/plugins/newtab/skills/widgets-scaffold/SKILL.md
@@ -78,26 +78,38 @@ The registry-centric core (do these first, in order):
    `WIDGET_ROW_COMPONENTS`. If the spec has `hasSidebar: true`, also add a
    sidebar component to `WIDGET_SIDEBAR_COMPONENTS` — see
    `references/SidebarVariant.md` for that wiring.
+5. `Widgets/Widgets.jsx` — add the widget's id to the hand-maintained
+   `widgetEnabledMap` object (mirror the `clocks`/`sportsWidget` entries):
+   `{key}: isWidgetEnabled(WIDGET_REGISTRY.find(w => w.id === "{key}"), prefs, widgetsEnabled)`.
+   **This is the one place the container is NOT yet registry-driven** (see the
+   `Bug 2034542` TODO above the map). The render loop gates every widget on
+   `widgetEnabledMap[id]`, so a widget missing from this map silently never
+   renders — even though its registry entry, component-registry entry, and prefs
+   are all correct. This is the single most common reason a freshly-scaffolded
+   widget shows nothing on `about:newtab`. (Until Bug 2034542 lands, "don't
+   hand-wire enabled-logic into Widgets.jsx" has this one exception.)
 
 The supporting files (each widget still touches these):
 
-5. `Widgets/{Name}/_{Name}.scss` — styles. Add `&.medium-widget { grid-row: span 2; }`
+6. `Widgets/{Name}/_{Name}.scss` — styles. Add `&.medium-widget { grid-row: span 2; }`
    and `&.large-widget { grid-row: span 4; }` inside the root class; add
    `&.small-widget { grid-row: span 1; }` only if `validSizes` includes `"small"`.
-6. `content-src/styles/activity-stream.scss` — add `@import` of the widget SCSS.
-7. `stylelint-rollouts.config.js` (repo root) — add the SCSS path in alphabetical
+7. `content-src/styles/activity-stream.scss` — add `@import` of the widget SCSS.
+8. `stylelint-rollouts.config.js` (repo root) — add the SCSS path in alphabetical
    order alongside the other widget entries.
-8. `lib/AboutPreferences.sys.mjs` + `browser/locales/en-US/browser/preferences/preferences.ftl`
+9. `lib/AboutPreferences.sys.mjs` + `browser/locales/en-US/browser/preferences/preferences.ftl`
    — register the widget for `about:preferences#home` (see notes.md) with a
    `home-prefs-{css-class}-header` string.
-9. Customize panel toggle (all required, see notes.md):
+10. Customize panel toggle (all required, see notes.md):
    `Base.jsx` (compute `mayHave{Name}Widget` and pass it to **both**
    `<CustomizeMenu>` renders) → `CustomizeMenu.jsx` (passthrough) →
    `Nova/CustomizeMenu/WidgetsManagementPanel/WidgetsManagementPanel.jsx` (add
    the `moz-toggle`) → `ContentSection.jsx` (classic path) →
    `browser/locales/en-US/browser/newtab/newtab.ftl` (toggle label).
-10. `test/jest/content-src/components/Widgets/{Name}.test.jsx` — a dedicated Jest
+11. `test/jest/content-src/components/Widgets/{Name}.test.jsx` — a dedicated Jest
     test file. New tests go in Jest (not the legacy `test/unit/` Enzyme suite).
+    Note: `WidgetsRegistry.test.jsx` has hardcoded expected widget-order arrays —
+    adding an entry breaks them until you append the new id (in registry order).
 
 Additional files only if the spec requires them:
 - `common/Actions.mjs` + `common/Reducers.sys.mjs` — only if Redux state is

--- a/plugins/newtab/skills/widgets-scaffold/references/ExampleWidget/_ExampleWidget.scss
+++ b/plugins/newtab/skills/widgets-scaffold/references/ExampleWidget/_ExampleWidget.scss
@@ -7,13 +7,11 @@
 // Root class is the css-class form of the registry id — no "-widget" suffix
 // (the shared `widget` class is applied alongside it). e.g. id "example".
 .example {
-  @include newtab-card-style;
-
-  border-radius: var(--border-radius-large);
-  padding: var(--space-medium);
-  display: flex;
-  flex-direction: column;
-  box-shadow: var(--box-shadow-card);
+  // widget-base-style provides the shared card visuals AND the per-size card
+  // height (small/medium/large), hover, transitions, and position. Do NOT use
+  // newtab-card-style directly -- it has no height, so a sparse or not-yet-wired
+  // widget body collapses.
+  @include widget-base-style;
 
   // Grid-row span per size. Add &.small-widget only if validSizes includes
   // "small" (and the widget stays in the row, i.e. hasSidebar is false).

--- a/plugins/newtab/skills/widgets-scaffold/references/notes.md
+++ b/plugins/newtab/skills/widgets-scaffold/references/notes.md
@@ -57,6 +57,32 @@ SportsWidget *does* have a per-widget Nova gate; that is legacy and must not be
 copied. (Older widgets like FocusTimer/Lists also carry conditional Nova logic
 because they predate the registry — new widgets don't need any of it.)
 
+## widgetEnabledMap in Widgets.jsx — the one spot still hand-wired
+
+The registry drives almost everything, but `Widgets.jsx` still builds a literal
+`widgetEnabledMap` object by hand (there is a `Bug 2034542` TODO above it to make
+this registry-driven). The render loop gates every widget on
+`widgetEnabledMap[id]`, so a widget that is missing from this map **silently never
+renders** even when its registry entry, `WIDGET_ROW_COMPONENTS` entry, and prefs
+are all correct — and `about:newtab` shows nothing with no error. This is the most
+common "I scaffolded a widget and it doesn't appear" cause.
+
+Add an entry mirroring `clocks`/`sportsWidget`:
+
+```js
+const widgetEnabledMap = {
+  // ...existing entries...
+  {key}: isWidgetEnabled(
+    WIDGET_REGISTRY.find(w => w.id === "{key}"),
+    prefs,
+    widgetsEnabled
+  ),
+};
+```
+
+Until Bug 2034542 lands, this is the documented exception to "do not hand-wire
+enabled-logic into `Widgets.jsx`".
+
 ## Size: resolveWidgetSize and the empty-string sentinel
 
 `resolveWidgetSize(entry, prefs)` applies priority:

--- a/plugins/newtab/skills/widgets-scaffold/scripts/gather_requirements.py
+++ b/plugins/newtab/skills/widgets-scaffold/scripts/gather_requirements.py
@@ -254,6 +254,8 @@ def main():
     trainhopEnabledKey: "{trainhop_enabled}",
     trainhopSizeKey: "{trainhop_size}",
     trainhopSidebarKey: {sidebar_key_literal},
+    widgetsSettingsVisibleKey: "{widget_key}Visible",
+    widgetsSettingsEnabledKey: "{trainhop_enabled}",
   }},"""
     )
     print("\n  Pref-key constants to export from the same file:")


### PR DESCRIPTION
The registry-based scaffold workflow omitted the one place Widgets.jsx is still hand-wired -- the widgetEnabledMap object ([Bug 2034542](https://bugzilla.mozilla.org/2034542)). The render loop gates every widget on widgetEnabledMap[id], so a scaffolded widget whose registry entry, WIDGET_ROW_COMPONENTS entry, and prefs are all correct silently never renders and about:newtab shows nothing with no error.

- SKILL.md: add core step 5 (add the id to widgetEnabledMap), renumber the supporting files, and note that WidgetsRegistry.test.jsx has hardcoded widget-order arrays that need the new id appended.
- references/notes.md: add a gotcha section with a copy-paste snippet.
- scripts/gather_requirements.py: emit the widgetsSettingsVisibleKey / widgetsSettingsEnabledKey registry fields (required by WidgetsRegistry.mjs but previously missing from the generated entry).
