### PR TITLE
Add CODEOWNERS for plugins

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,6 @@
+*                              @mozilla/ai4dev
+
+# Code owners for specific plugins
+/plugins/figma/                @rocketsroger
+/plugins/ipprotection/         @msujaws
+/plugins/newtab/               @maxxcrawford


### PR DESCRIPTION
Catch-all ownership by @mozilla/ai4dev plus per-plugin owners.