### PR TITLE
tae: refresh test-review skill and add authoring + conversion-loop sk…

### DIFF
--- a/plugins/tae/.claude-plugin/plugin.json
+++ b/plugins/tae/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "tae",
   "description": "Skills and tools for Test Automation Efficiency (UI Test) development",
-  "version": "1.0.0"
+  "version": "1.1.0"
 }

--- a/plugins/tae/README.md
+++ b/plugins/tae/README.md
@@ -1,11 +1,57 @@
 # Fenix TAE Test Plugin
 
-Skills for authoring and reviewing tests in the Fenix TAE efficiency test framework.
+Skills for authoring, reviewing, and landing tests in the Fenix TAE efficiency test
+framework at
+`mobile/android/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/efficiency/`.
+
+The three skills cover one workflow end to end — **author → review → land** — and are
+useful independently.
 
 ## Skills
 
+### `efficiency-test-authoring`
+
+Author or convert a Fenix UI test onto the ui/efficiency framework. Picks the cheapest
+viable build mode (factory-generated, hand-composed, or compose-plus-extend) and walks
+the per-test feedback loop: pick a candidate, scaffold, resolve navigation, choose
+selectors from real handles, static pre-flight, build/run, then audit parity against the
+legacy test.
+
+Use it when writing a new efficiency test or porting a legacy robot-based one.
+See [`skills/efficiency-test-authoring/SKILL.md`](skills/efficiency-test-authoring/SKILL.md).
+
 ### `tae-test-review`
 
-Authoring and review guidance for the Fenix TAE efficiency test framework, covering the three test types, page objects, selectors, navigation, primitives, and a review rubric with severity tiers and migration-era triage for temporary smoke conversions.
+Review rubric and authoring guidance: the three test types, page objects, selectors,
+navigation, primitives, severity tiers, and migration-era triage for temporary smoke
+conversions. Leads with the **parity audit** — the check a green CI run actively
+disguises, because a dropped assertion doesn't fail, it passes for the wrong reason.
 
-Use this skill when authoring or reviewing changes under `mobile/android/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/efficiency/`. See [`skills/tae-test-review/SKILL.md`](skills/tae-test-review/SKILL.md) for details.
+Use it when reviewing a diff, PR, or Phabricator revision touching the framework, or as
+a pre-submission self-check.
+See [`skills/tae-test-review/SKILL.md`](skills/tae-test-review/SKILL.md).
+
+### `efficiency-conversion-loop`
+
+The paperwork around a finished conversion: file a Bugzilla bug, commit with the real bug
+number, track the conversion/enablement split in Jira, and open a moz-phab review.
+
+Use it once a conversion is written and needs to become a landed patch.
+See [`skills/efficiency-conversion-loop/SKILL.md`](skills/efficiency-conversion-loop/SKILL.md).
+
+## What this plugin does not contain
+
+**Reference documentation.** The authoring guides, harness gotcha catalog, and
+architecture docs live in-tree under `<framework-root>/docs/` and are the source of
+truth. The skills point at those paths rather than vendoring copies, so there's one place
+to update.
+
+**The host-side toolchain.** The `eff*` scripts the skills drive (`effnext`,
+`effscaffold`, `effcheck`, `effbuild`, `effverify`, `effloop`, and the `effwatch` bridge)
+live in [`testops-tools`](https://github.com/mozilla-mobile/testops-tools) under
+`tae-conversion/`. They run on the engineer's machine and talk to a device, Bugzilla, and
+Phabricator — that's infra tooling, not something to ship inside a plugin. The
+device-side dump tools (`effview`, `effpretty`) ship in-tree under
+`<framework-root>/devtools/`.
+
+Skills work without the toolchain for authoring and review. The conversion loop needs it.

--- a/plugins/tae/skills/efficiency-conversion-loop/SKILL.md
+++ b/plugins/tae/skills/efficiency-conversion-loop/SKILL.md
@@ -1,0 +1,111 @@
+---
+name: efficiency-conversion-loop
+description: >
+  Run the end-to-end loop for landing a legacy Fenix UI test converted onto the ui/efficiency
+  framework: convert → file a Bugzilla bug → commit with the real bug number → track in Jira
+  (conversion vs. enablement) → open a moz-phab review. Use this when a conversion is written and
+  needs to become a filed bug, a properly-numbered commit, Jira tracking, and a submitted revision —
+  i.e. the "paperwork + submit" workflow around a ui/efficiency conversion, not the test authoring
+  itself (that's the efficiency-test-authoring skill). Also covers keeping the tracker/dashboards in
+  sync after landing.
+---
+
+# ui/efficiency conversion loop
+
+This skill drives the workflow *around* a conversion once the test itself is written. Test authoring
+is a separate skill (`efficiency-test-authoring`). The five steps:
+
+**convert → file bug → commit (with bug #) → track in Jira → submit for review**
+
+## What runs where
+
+- **The agent (sandbox)** does the conversion, static checks, and drives the bridge; it creates Jira
+  items via the Atlassian connector. It **cannot** reach the repo, Bugzilla, or Phabricator directly.
+- **The host bridge (`effwatch`)** runs the git + Bugzilla actions on the engineer's machine and returns
+  results. It never pushes and never submits.
+- **The engineer** runs `effwatch`, keeps a device attached, and runs the final `moz-phab submit`.
+
+The eff\* tools live in the **testops-tools** repo under `tae-conversion/tools/` (see
+`tae-conversion/README.md` for setup). Clone that repo and start `effwatch` before using this loop.
+
+## Prerequisites (one-time)
+1. `effwatch` running on your machine (from `testops-tools/tae-conversion/tools/`), device/emulator attached.
+2. A Bugzilla API key available to effbug — set it once in `~/.zshenv` (`export BUGZILLA_API_KEY=…`) or a
+   `tae-conversion/tools/.eff.env` file (gitignored). Never paste it into chat.
+3. `moz-phab` installed and authenticated to phabricator.services.mozilla.com.
+
+## Project-specific IDs — edit these for your team
+
+This skill is written for the Fenix smoke-conversion campaign. If you're running it elsewhere, these are
+the only values you need to change:
+
+| Value | Current | What it's for |
+|---|---|---|
+| Template bug | `2057054` | Cloned for product/component/version → Firefox for Android :: UI Tests |
+| Reviewers | `isabel_rios`, `aaronmt` | Default Phabricator reviewers (`EFF_REVIEWERS`) |
+| Conversion parent | `MTE-5731` | Story that conversion sub-tasks hang off |
+| Enablement parent | `MTE-5715` (or `MTE-5688`) | Harness-hardening / tech-debt story |
+| Jira cloud | `mozilla-hub.atlassian.net` | Atlassian connector target |
+
+## The loop
+
+### 1. Convert + pre-flight
+Convert the legacy test onto ui/efficiency (see efficiency-test-authoring). Run `effcheck.py` (static
+pre-flight) then build/run via the bridge (`effverify` / `effwatch`) until green, or "good enough + notes."
+
+Before you file anything: run the **parity audit** from the `tae-test-review` skill. A conversion that
+dropped a legacy assertion still goes green, so a passing run is not the gate — the legacy-vs-port diff is.
+Land-blocking findings are cheaper to fix now than after the bug and commit exist.
+
+### 2. File the Bugzilla bug (agent → bridge → `effbug`)
+Drop `conversion-runs/_queue/<id>.request.json`:
+```json
+{ "bug": "create",
+  "summary": "[efficiency] Convert <Test>.<method> to ui/efficiency",
+  "comment": "<what was ported; parity notes>",
+  "why": "<one-line rationale>",
+  "kind": "conversion",            // conversion | enablement | tooling — picks the description footer
+  "testrail": "<id(s)>",
+  "template_bug": "2057054",        // clones product/component/version → Firefox for Android :: UI Tests
+  "type": "task" }
+```
+`effbug` files the bug, then **rewords the title to `Bug NNNNN - <summary>`** so it matches the commit
+subject exactly, and **self-assigns** to the API-key owner. It returns the number in
+`_bug/<id>.bug-result.json`.
+
+### 3. Commit with the real bug number (agent → bridge → `effgit`)
+Write the commit message to `conversion-runs/<batch>/msg.txt` with `Bug NNNNN - [efficiency] … r=isabel_rios,aaronmt`
+then drop `{ "git":"commit", "message_file":"<batch>/msg.txt", "paths":[...] }`. (If a commit already exists
+with a placeholder, backfill by rewording — the loop files the bug *before* committing going forward, so no
+reword is needed.)
+
+### 4. Track in Jira (agent → Atlassian connector)
+Separate strict conversion from the enablement it sometimes forces, so conversion effort can be measured:
+- **Conversion** → a **Sub-task labelled `conversion`** under the Smoke-conversion campaign story **MTE-5731**.
+- **Tooling/enablement** discovered during conversion → a **separate Sub-task labelled `enablement`** under
+  Harness Hardening **MTE-5715** (or Tech-Debt **MTE-5688**), **linked** ("Relates") to the conversion sub-task.
+- Create with `issueTypeName: "Sub-task"`, `additional_fields: {"labels":[...]}`, and self-assign via
+  `assignee_account_id`. Put the bug number + Phab revision in the item. cloudId = `mozilla-hub.atlassian.net`.
+
+### 5. Submit the finished stack (engineer)
+Submitting/landing stays with the engineer. **Mozilla's moz-phab has no `--dry-run`** — it's interactive: it
+prints the commit list and prompts Y/n before creating anything (that's your preview). Bound the range so it
+can't touch already-landed base commits:
+```
+moz-phab submit --reviewer isabel_rios --reviewer aaronmt <first-new-commit>
+```
+(or `python3 tae-conversion/tools/effsubmit.py --start <first-new-commit> --execute`). Then add the
+`testing-exception-unchanged` tag in the Phabricator web UI (no moz-phab CLI flag exists for it). moz-phab
+keys off `Differential Revision:` trailers, so base commits that carry them are excluded automatically — even
+if they landed on autoland and aren't in your local central yet.
+
+## After landing
+Re-sync the tracker so conversion counts + `@Converted` annotations catch up (see
+`tae-conversion/README.md` → "Reconciling the ledger" and `tae-conversion/tools/reconcile_conversion.py`),
+and annotate the converted legacy methods with `@Converted(replacedBy = [...], bug = NNNNN, since = "YYYY-MM")`
+once green + landed. Record any coverage that didn't carry over in the annotation's `notes` parameter.
+
+## Conventions
+- **Faithful-port-first:** don't rewrite behavior during conversion; log quality ideas separately.
+- One bug per landable unit; mirror any conversion/enablement split in the Jira items.
+- Bugs + Jira items are self-assigned back to the engineer who ran the loop.

--- a/plugins/tae/skills/efficiency-test-authoring/SKILL.md
+++ b/plugins/tae/skills/efficiency-test-authoring/SKILL.md
@@ -1,0 +1,160 @@
+---
+name: efficiency-test-authoring
+description: >
+  Author or convert Fenix Android UI tests onto the ui/efficiency framework. Use this whenever the
+  task involves writing a new efficiency UI test, converting/porting a legacy ui/ (robot-based) test
+  onto the efficiency framework, or building what a test needs — page objects, selectors,
+  navigation-graph nodes/edges, or BasePage primitives. Trigger even when the user doesn't name the
+  framework: "convert this smoke test", "add a page object for the bookmarks screen", "wire up
+  navigation to Settings", "write an efficiency test for X" all qualify. Do NOT use for edits to
+  legacy robot-based tests that are staying on the old framework, or for non-Android test work.
+---
+
+# Efficiency test authoring
+
+This skill turns "I need this UI test on the efficiency framework" into a reliable, repeatable
+build. Its job is to (1) figure out which of three build modes a test needs and (2) route you to
+the right rule-set for each missing piece. The detailed rules live **in-tree** — read only the
+one(s) you need, when you need them.
+
+Framework root in the repo (called `<eff>` below):
+`mobile/android/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/efficiency/`
+
+Every `docs/…` path in this skill is relative to `<eff>`. Those docs are the source
+of truth — read them from the tree rather than relying on a summary here, since the
+monorepo moves under you.
+
+The host-side `eff*` scripts this skill drives (`effnext`, `effscaffold`, `effcheck`,
+`effbuild`, `effverify`, `effloop`, the `effwatch` bridge) live in the
+**testops-tools** repo under `tae-conversion/tools/`. The device-side dump tools
+(`effview`, `effpretty`) ship in-tree at `<eff>/devtools/`.
+
+## Status: this is a v0 guide we are dogfooding (read this)
+
+This skill is refined as we go — it is **not a hard rule set yet**. Treat it as the **live** guide
+and follow it, but when we agree on something that isn't aligned with what's written here, **stop and
+flag the mismatch, discuss it, then update this skill (and the reference/logs) at that time.** New
+lessons land first in the running logs and get folded up into this skill:
+- `<eff>/docs/gotchas.md` — harness bug catalog + authoring/review checklist (A* bugs, B* checks),
+  distilled and landed in-tree.
+- `testops-tools/tae-conversion/docs/HARNESS-GOTCHAS.md` — the running catalog, ahead of the in-tree
+  copy while entries are still being confirmed.
+- `testops-tools/tae-conversion/docs/CONVERSION-LESSONS.md` — assumption→reality→rule, tagged by
+  whether a tool enforces it.
+Check those as if they were part of this skill; they are the source the skill distills.
+
+## Three build modes (cheapest first)
+
+Every test is one of these. Picking the cheapest workable mode is the point.
+
+1. **Factory-generated** — a factory emits the test from metadata; you write nothing. Today only the
+   Reachability factory is production-ready (covers "does this page open" for pages already in the
+   graph). Prefer this for pure page-open checks.
+2. **Hand-composed** — write the test by composing existing building blocks (`BasePage` `moz*`
+   verbs, page objects, selectors, nav nodes). Default for real smoke tests; usually ~5–20 lines.
+   **Reuse first:** a lot of capability already exists (custom-tab launch, trust-panel state verify,
+   recently-closed screen, web-form submit + save-login prompt, settings→Home back-edge, screen-dump
+   dev tools). Check before building.
+3. **Hand-composed + extend the harness** — a needed block is missing, so add it first (page object /
+   selectors / nav node / primitive), then compose. Extending is the exception — add the smallest
+   general thing; every extension is reusable by later tests.
+
+## The feedback loop (run this per test)
+
+Work the gates in order. At each gate you either compose with what exists or add the missing block,
+then continue. Navigation is the spine — resolve reachability first. Lean on the tools (below); they
+make each gate faster and safer than doing it by hand.
+
+0. **Pick the next test (local, no network).** Run `effnext --json` — next unconverted candidate(s) from
+   the local prioritized pool minus what's done. **Never call the Google Sheet to choose** — it's slow and
+   the local pool is the working queue. (The Sheet is systems-of-record for status, not the per-test picker.)
+1. **Scaffold + extract intent.** Run `effscaffold <Class.method> --json` first — it pulls the legacy
+   body, TestRail id, whether an efficiency test of that name already exists (don't re-convert!), the
+   robots + their selector lines, and which screens are already modeled. From that, write the
+   template: entry state, target page(s), ordered steps, assertions. Keep the *what*; drop legacy DSL.
+2. **Navigation gate.** Can you route to each target page? Before choosing selectors, **discover the
+   real handles** an element exposes — never trust a stubbed locator. → `docs/guides/discovering-selectors.md`
+   (uses `effdump`). If a page object, its selectors, or a nav edge is missing, build it. →
+   `docs/guides/adding-navigation.md`, `docs/guides/creating-a-page-object.md`, `docs/guides/authoring-selectors.md`.
+3. **Interaction gate.** Expressible with existing `moz*` verbs? Reuse first. If not, add a primitive
+   or page-object helper — new verbs go through `resolve()` and keep its guarantees (exception-safe
+   presence, preserve per-strategy Compose tree). → `docs/guides/extending-basepage.md`.
+4. **Assertion gate.** Verifications expressible (`mozVerify*` family)? If not, add a verify primitive.
+   → `docs/guides/extending-basepage.md`.
+5. **Static pre-flight.** Run `effcheck … --json` before spending a device build — it catches string/id
+   resolution, empty nav paths (gotcha B1), inline selectors (B2), missing BasePage verbs, and
+   test-class boilerplate (MWS/IMP). Fix everything it flags first.
+6. **Write + run + verify — JSON verdict only.** Compose the test → `docs/guides/writing-a-test.md`. Build+run
+   it in isolation via the bridge, then read **only** `effbuild --json` (compile verdict + error lines) and
+   `effverify … --json` (the named test ran, was NOT skipped, `failed_total`=0, and `clean`=true i.e. not a
+   retry-pass). **Do NOT `cat` `run-report.txt` / `raw-run.log`, and do NOT read `effpretty` output** — on a
+   failure, `effverify --json` now carries a capped `failure_excerpt` (exception + top frames) which is all you
+   need. `effpretty` is for a human eyeballing a run, not for the agent. "green + 0 failed" alone is NOT proof;
+   a retry-pass (`clean`=false) is flaky, not done. → `docs/guides/debugging-tests.md`.
+   On a failed step the auto-dump now covers all three layers plus a **window/focus summary** — read the
+   `[windows]` block first to tell "covered by an overlay / focus stolen" from "element genuinely absent"
+   before touching a selector. Blocking overlays are auto-dismissed via `OverlayRegistry`; add new ones
+   there rather than handling them in a test.
+7. **Parity + close-out.** Diff the legacy body against the port and list every legacy `verify*` — in the
+   test **and in the robot helper it delegates to**, where retry/refresh semantics hide. Each one needs an
+   explicit counterpart or a documented gap. Green is not evidence of parity: a dropped assertion doesn't
+   fail, it passes for the wrong reason, and what gets dropped is usually the *payload* check
+   (`verifyPageContent`, `verifyUrl`, a tab count) rather than the navigation. Never justify an omission
+   with "`navigateToPage` already checks it" — an implicit assertion can't be audited. If you omit a leg
+   (e.g. no stateful return edge), **log it as a harness gap** in the test and the commit message — don't
+   silently drop it. THEN annotate the legacy test with `@Converted` (only after green + landed — the
+   burndown keys off it):
+   ```kotlin
+   @Converted(
+       replacedBy = ["org.mozilla.fenix.ui.efficiency.tests.AutofillTest#verifyAddressAutofillTest"],
+       bug = 2057958,
+       since = "2026-07",
+       notes = "Legacy also asserted X; not carried over — see bug NNNNN.",
+   )
+   ```
+   `replacedBy` is required and every entry must resolve to a real, non-`@Ignore`d `@Test` (validated by
+   the conversion lint check). Use `notes` for coverage that intentionally did not carry over — that's the
+   mechanism the parity rule above asks for. The legacy test keeps running alongside the replacement until
+   the replacement has been green on main for the configured cadence.
+8. **Land it.** Hand off to the **efficiency-conversion-loop** skill for bug → commit → Jira → submit.
+9. **Feedback.** Recurring shape (nav→click→verify) → flag as a factory candidate. Every new
+   assumption-correction → add to `CONVERSION-LESSONS.md`; if it changes the workflow, update this skill.
+
+## Tools (fast + safe; prefer `--json` when driving them programmatically)
+
+| Tool | Use at | Does |
+|---|---|---|
+| `effnext` | gate 0 | Next unconverted candidate(s) from the local pool minus done. Local-only, no network. `--json`. |
+| `effscaffold` | gate 1 | Legacy body, TestRail, already-converted check, robots+selectors, existing coverage. |
+| `effdump` / `ScreenDump` | gate 2 | Dumps a screen's real handles in all 3 layers (Compose / Espresso / UIAutomator). Author from ground truth, not stubs. |
+| `effcheck` | gate 5 | Static pre-flight (no device) — resolution, nav, inline selectors, verbs, boilerplate. |
+| `effbuild` | gate 6 | Compile verdict + only the error lines. `--json`. Read this, not the raw build log. |
+| `effverify` | gate 6 | Done-gate (scoped to the **last** run): `ok`/`clean`, `failed_total`, `runs`, `retried`, and a capped `failure_excerpt` on failure. `--json` — the agent reads THIS, never the raw report. |
+| `effpretty` | (human) | Renders the `Eff` run log for a **person** inspecting a run. Not part of the agent's read path. |
+| effwatch bridge | gate 6 | Runs the build/run on the engineer's device and returns reports. |
+
+Gates **3 (interaction)** and **4 (assertion)** have no tool — they're code edits (add a `moz*` verb or a
+`mozVerify*` primitive) via `docs/guides/extending-basepage.md`. `effwatch` is a persistent bridge you start once,
+not a per-step tool; `effscaffold`/`effcheck`/`effbuild`/`effverify` may each run several times per test.
+
+## Reference rule-sets
+
+| When you need to… | Read |
+|---|---|
+| Find an element's real handles before choosing a strategy (`effdump`, stubs, web ids, state-invariance) | `docs/guides/discovering-selectors.md` |
+| Reach/route to a screen; add graph nodes/edges; onboarding/launch-flag entries | `docs/guides/adding-navigation.md` |
+| Model a new screen | `docs/guides/creating-a-page-object.md` |
+| Add element locators + their groups | `docs/guides/authoring-selectors.md` |
+| Compose the actual test method | `docs/guides/writing-a-test.md` |
+| Add a `moz*` primitive or page-object helper | `docs/guides/extending-basepage.md` |
+| Run and debug a test (effpretty, ScreenDump, retry-masking, SKIPPED trap) | `docs/guides/debugging-tests.md` |
+
+## Guardrails
+
+- Tests describe only the *what*; the harness owns the *how* (navigation, retries, selectors).
+- Reuse an existing capability before adding one; add the smallest general block, not a test-specific hack.
+- Selector priority: Compose `testTag` → resource id → content-description → text (last resort). Verify
+  handles against the live app UI (via `effdump`), not from how a legacy robot matched.
+- Verify every claim against the live repo; it's a syncing monorepo and state shifts between runs.
+- This skill is a soft v0 — when reality and the skill disagree, flag it, discuss, then update the skill.
+- You can draft skill content but can't install it from a Cowork session — install via Settings → Capabilities.

--- a/plugins/tae/skills/tae-test-review/SKILL.md
+++ b/plugins/tae/skills/tae-test-review/SKILL.md
@@ -9,8 +9,9 @@ description: >-
   files. Also use when authoring a new test and self-checking before submission,
   when asked to check a test against TAE conventions, classify a test
   (presence/interaction/behavior), or judge whether a helper belongs in a page
-  object vs. BasePage. Applies the framework's principles and anti-patterns as a
-  review rubric with severity tiers.
+  object vs. BasePage. Also use when auditing a converted test for assertion
+  parity against the legacy test it replaces. Applies the framework's principles
+  and anti-patterns as a review rubric with severity tiers.
 ---
 
 # Contributing to the TAE Test Framework
@@ -28,7 +29,8 @@ This one document serves two audiences:
   known gaps so review is one pass, not a loop.
 - **Reviewers — during code review.** Work from "Conducting a review". It routes
   you to the relevant principles and anti-patterns and gives severity tiers so
-  your feedback tells the author what blocks merge.
+  your feedback tells the author what blocks merge. For a conversion, start with
+  the "Parity audit" — it is the one check a green test cannot substitute for.
 
 Both audiences share the same rules; the only difference is who applies them and
 when.
@@ -51,13 +53,19 @@ Identify what the diff touches, because different files get different scrutiny:
 - **Selectors** (`selectors/*Selectors.kt`) — check anchor stability, group
   assignment, and that nothing is defined inline in a test.
 - **BasePage / helpers** — highest bar. A new primitive on BasePage is a
-  blocking discussion, not a rubber stamp.
+  blocking discussion, not a rubber stamp. A new `SelectorStrategy` has a
+  specific two-path wiring trap — see anti-patterns.
+- **`devtools/*.kt`** — anything with an `@Test` in this package runs on
+  Firebase, because the TAE flank config targets the whole package. Every
+  dev-only method needs `assumeFalse("dev tool, not a CI test", isTestLab())`.
 
 ### Severity tiers
 
 Label each finding so the author knows what blocks merge.
 
 **Blocking** — merge only after this is fixed:
+- A legacy assertion is missing from a conversion and the gap isn't documented
+  (see "Parity audit"). This one outranks everything else here.
 - Assertions interleaved with navigation in a Presence or Interaction test
   (see the Behavior exception below before flagging).
 - `Thread.sleep()` or a hand-rolled poll/wait loop.
@@ -67,6 +75,11 @@ Label each finding so the author knows what blocks merge.
 - `@After` used for state that must be clean for the next test to be valid.
 - Hard-coded click sequence to reach a page instead of a `navigateToPage()`
   edge.
+- A new `SelectorStrategy` added to only one of the two resolution paths
+  (`resolveComposeNode()`'s `candidates()` and `mozGetElement()`'s `when`). It
+  compiles and fails at runtime for whichever verb you didn't wire.
+- An `@Test` under `devtools/` without an `isTestLab()` guard — it will consume a
+  Firebase device slot on every TAE run.
 
 **Should-fix** — fix unless there's a stated reason:
 - Test can't be classified as one of the three types, or does too much to be one.
@@ -74,6 +87,15 @@ Label each finding so the author knows what blocks merge.
 - `mozVerifyElementsByGroup` used for runtime/dynamic data.
 - Popup/dialog handling added inside a test instead of in a primitive/config.
 - A wrapper method whose name adds no clarity over `primitive + selector`.
+- A selector switched from text to a tag, leaving what the text was *asserting*
+  unasserted — and often a now-dead parameter still passed by every caller.
+- A selector used by a class that sets `shouldUseExpandedToolbar = true` but only
+  verified in the default layout. That flag relocates controls and changes the
+  handles they expose.
+- A nav edge edited without grepping `to = "<TargetPage>"` across `pageObjects/`
+  first. Edges are sometimes registered twice, and the loser is invisible.
+- Step-by-step narration comments in a converted test (see "Comments in
+  converted tests").
 
 **Nit** — note it, don't block:
 - Group name could be more meaningful.
@@ -95,6 +117,11 @@ verifies its stated behavior. A green test that doesn't test the thing is
 if these hand-conversions seed factory templates, the wrong assertion
 propagates. So correctness findings stay land-blocking no matter how the gate
 below scores them.
+
+For a conversion, "correctness" means **assertion parity with the legacy test**,
+established by the diff in "Parity audit" — not by the test passing. A review of
+one 13-conversion stack found **17** legacy assertions silently missing, and none
+of them caused a failure.
 
 **Cost-of-fix gate.** For every non-correctness finding, before requesting the
 change, ask:
@@ -138,8 +165,68 @@ primitive.
 - **Batch, don't iterate.** Deliver one consolidated pass ("N trivial fixes, M
   deferred to cleanup") rather than a multi-round loop.
 
+### Parity audit (conversions only)
+
+**A dropped assertion does not fail — it passes for the wrong reason.** This is
+the single highest-yield check in a conversion review, and the only one that a
+green CI run actively disguises.
+
+`navigateToPage()` silently verifies every selector in the target page's
+`requiredForPage` group. That makes a legacy `verifyPageContent(...)` or
+`verifyUrl(...)` look redundant, so it gets dropped. What survives is the
+*navigation* assertion; what disappears is the *payload* assertion. The test
+still proves it reached a screen. It stops proving the screen is right.
+
+The audit:
+
+1. Open the legacy test body and the port side by side.
+2. List every legacy verification — `verify*` calls in the test **and** in the
+   robot helper it delegates to.
+3. Tick each one off against an explicit assertion in the port.
+4. Anything unticked is either added back explicitly, or documented as a gap in
+   **both** the test and the commit message. There is no third option.
+
+When the legacy test gets annotated (after the port is green and landed), that
+annotation is where a documented gap belongs permanently:
+
+```kotlin
+@Converted(
+    replacedBy = ["org.mozilla.fenix.ui.efficiency.tests.AutofillTest#verifyAddressAutofillTest"],
+    bug = 2057958,
+    since = "2026-07",
+    notes = "Legacy also asserted X; not carried over — see bug NNNNN.",
+)
+```
+
+In review, check that `replacedBy` points at a real non-`@Ignore`d `@Test` (the
+conversion lint check validates this) and that any parity gap you found in step 4
+is recorded in `notes` rather than left in a review comment.
+
+Do not accept "`navigateToPage` already checks it" as a justification. An
+implicit assertion is invisible to the next person diffing the port against the
+legacy test, which makes the conversion impossible to audit. A faithful port now
+with duplicated-looking lines beats a tidy port that quietly lost coverage; house
+style gets settled in a later dedicated refactor pass.
+
+Two related traps:
+
+- **Tag swaps delete content assertions.** When a selector moves from text
+  matching to tag-only (a legitimate fix for ambiguity — see the toolbar/address
+  bar duplication), ask what the text was *asserting*. If it was content, match
+  both with `COMPOSE_BY_TAG_AND_TEXT`. Otherwise the assertion degrades to "an
+  element with this tag exists", which is nearly always true, and the parameters
+  carrying the expected values become dead — passed by every caller, read by
+  nothing.
+- **Report the inventory and the provenance.** When summarising a stack as
+  "green", state which classes the count covers and *whose* runs it covers. An
+  agent's verification and a human's are separate sets and neither is visible to
+  the other unless recorded. "39 tests green across 6 classes" for a 7-class
+  stack reads as full coverage with one class silently missing.
+
 ### Triage checklist (per changed test)
 
+0. If it's a conversion, run the **Parity audit** first. Everything below is
+   structure; this is whether the test still tests the thing.
 1. Classify it: Presence, Interaction, or Behavior. If you can't, that's a
    should-fix — the author doesn't have a clear subject.
 2. Strip the navigation mentally. Does the remaining body read as one coherent
@@ -154,6 +241,10 @@ primitive.
 6. Check every new page-object method: does it earn a `[STEP]`, and does it stay
    on the page it operates on?
 7. Check navigation: is every hop a registered edge?
+8. For a conversion, read the legacy **robot** helper, not just the legacy test
+   body. Retry/refresh semantics, per-assertion waits, and fallback behaviour
+   live in the robot. Porting the body alone yields a test that looks correct and
+   is flaky.
 
 ### The Behavior-test exception (read before flagging "interleaved assertions")
 
@@ -316,11 +407,11 @@ Define selectors once in the appropriate `selectors/*Selectors.kt` file. Assign 
 
 `mozClick`, `mozSwipeTo`, `mozVerify`, `mozVerifyElementsByGroup`, `mozEnterText`, `mozPressEnter` -- these are your building blocks. Compose tests from them.
 
-> Verified against `helpers/BasePage.kt` on 2026-07-06. This is a point-in-time
+> Verified against `helpers/BasePage.kt` on 2026-07-29. This is a point-in-time
 > snapshot — new primitives are added over time, so treat the current BasePage
-> source as authoritative if it differs. `mozVerifyElement` and `mozClear` are
-> **internal** to BasePage and are intentionally omitted; do not call them from
-> tests.
+> source as authoritative if it differs. `mozVerifyElement`, `mozGetElement`, and
+> `resolve` are **private** to BasePage; don't reach for them from tests or page
+> objects.
 
 ### Interaction primitives
 
@@ -331,6 +422,7 @@ Define selectors once in the appropriate `selectors/*Selectors.kt` file. Assign 
 | `mozClickIfPresent(selector)` | Click only if the element is present (no failure if absent) |
 | `mozClickFirstWithParentText(selector, parentText)` | Click the first match under a parent with given text |
 | `mozEnterText(text, selector)` | Enter text into a field |
+| `mozClear(selector)` | Clear a field |
 | `mozClearAndEnterText(text, selector)` | Clear then enter text |
 | `mozPressEnter(selector)` | Press the IME enter key on the field |
 | `mozSwipeTo(selector)` | Swipe until an element is visible |
@@ -355,8 +447,20 @@ Define selectors once in the appropriate `selectors/*Selectors.kt` file. Assign 
 | `mozVerifyElementIsEnabled` / `mozVerifyElementIsNotEnabled` | Verify enabled state |
 | `mozVerifyElementHasCheckedSiblingByResName` | Verify a sibling (by res name) is checked |
 | `mozVerifyElementHasSiblingWithText` | Verify a sibling has given text |
+| `mozVerifyKeyboardVisible()` / `mozIsKeyboardVisible()` | Verify / query soft-keyboard visibility |
+| `mozVerifyFileOpensInExternalApp(...)` | Verify a file hands off to an external app |
 | `verifySnackbarText(text)` | Verify a snackbar shows the given text |
 | `waitForSnackbarToBeDismissed()` | Wait for the snackbar to dismiss |
+
+`dismissKnownOverlaysIfPresent()` is public but you should almost never call it —
+`mozClick` and `mozVerify` already fire it automatically on a locate miss and
+retry once. Register new blocking overlays in `helpers/OverlayRegistry.kt` instead
+of dismissing them from a test.
+
+`BrowserPage.verifyPageContentWithReload(url, text, attempts)` is a page-object
+method, not a BasePage primitive. Reach for it when content only appears after
+async work (blocked-tracker reports, for example) — a longer wait on the current
+document never helps, because the page has to be re-fetched.
 
 The state-verification family (`...IsSelected`, `...IsChecked`, `...IsEnabled`,
 sibling checks) is easy to overlook — reach for these before writing a custom
@@ -410,7 +514,39 @@ Groups turn element lists into meaningful assertions.
 
 ### Prefer existing selector strategies
 
-The 20+ strategies in `SelectorStrategy` cover Compose, Espresso, and UIAutomator. If none works, the UI itself may need a test hook (a test tag or content description) rather than a more complex selector.
+The 25 strategies in `SelectorStrategy` (`helpers/Selector.kt`) cover Compose,
+Espresso, and UIAutomator. If none works, the UI itself may need a test hook (a
+test tag or content description) rather than a more complex selector.
+
+Ones that are easy to miss because they solve a narrow problem:
+
+| Strategy | Reach for it when |
+|---|---|
+| `COMPOSE_BY_TAG_AND_TEXT` | A tag disambiguates *and* the text is the thing being asserted. This is the fix for a tag swap that would otherwise drop a content assertion. |
+| `UIAUTOMATOR_WITH_COMPOSE_TAG` | Matching a **web/GeckoView DOM id**. It matches the raw resourceId with no package prefix, which is what web content exposes. |
+| `UIAUTOMATOR_WITH_WEB_ID_AND_TEXT` | Raw web DOM id plus exact text — e.g. asserting an autofilled value in a form field. |
+| `UIAUTOMATOR_WITH_RES_ID_CONTAINING_TEXT` | Package-prefixed app res-id plus a text substring (mirrors legacy `itemWithResIdContainingText`). |
+| `UIAUTOMATOR_WITH_DESCRIPTION_CONTAINS` | A control that **moves between surfaces** — see below. |
+
+Note the app/web split: an app View res-id wants `UIAUTOMATOR_WITH_RES_ID`
+(which prepends `packageName:id/`), while a web DOM id (`submit`, `username`)
+needs a raw-resourceId strategy. Using the app one on web content silently
+matches nothing.
+
+### Controls that relocate need a device-level handle, not a tag
+
+`shouldUseExpandedToolbar = true` is not a restyle — it moves controls between
+surfaces and changes which handles they expose. Confirmed cases: the tab counter
+moves into the bottom navigation bar and exposes **no testTag at all**, only a
+content description; "Bookmark page" moves out of the main menu, so a Compose
+content-description lookup scoped to the menu finds nothing; the search
+placeholder becomes a text node with no content description.
+
+So a testTag cannot be "the stable handle" for a control whose tag doesn't exist
+in the other layout. Prefer a device-level
+`UIAUTOMATOR_WITH_DESCRIPTION_CONTAINS`, which resolves in both — see
+`ToolbarSelectors.TAB_COUNTER_ANY_LAYOUT`. In review: any selector used by a class
+that sets the flag must have been verified in *that* layout.
 
 ## Navigation
 
@@ -463,6 +599,12 @@ These should be flagged in code review:
 | Using `mozVerifyElementsByGroup` for dynamic data | Groups are compile-time; dynamic values won't match | Use individual `mozVerify` calls with parameterized selectors |
 | Using `@After` for critical state cleanup | If the runner crashes, `@After` is not called -- leaves dirty state that can break subsequent tests or worse, cause false passes from carried-over state | Push cleanup to pre-test setup, constructor flags, or runner-level mechanisms that run regardless of crash |
 | Handling unexpected popups in test assertions | System alerts, permission dialogs, and conditional modals break tests that aren't meant to verify them | Let custom commands handle view-blocking elements via fallback conditional checks -- this keeps the fix in one place (the primitive) rather than scattered across tests |
+| Dropping a legacy assertion as "covered by `navigateToPage`" | The navigation check survives, the payload check disappears; the port passes while testing less | Restore it explicitly, or document the gap in the test *and* the commit message (see "Parity audit") |
+| Swapping text matching for a tag without asking what the text asserted | Degrades the check to "an element with this tag exists" and leaves dead parameters behind | Use `COMPOSE_BY_TAG_AND_TEXT` when the text was the assertion |
+| Step-by-step narration comments in a converted test | Restates the code and buries the parity notes that actually carry information | Keep the conversion header, TestRail link, and parity/why notes; cut the narration |
+| A new `SelectorStrategy` wired into one resolution path | `mozClick` and `mozVerify` resolve differently; compiles clean, fails at runtime for the unwired verb | Wire both `resolveComposeNode()`'s `candidates()` and `mozGetElement()`'s `when` |
+| An `@Test` under `devtools/` with no `isTestLab()` guard | The flank config targets the whole package, so it burns a Firebase slot every run | `assumeFalse("dev tool, not a CI test", isTestLab())` — not `@Ignore`, which also blocks manual runs |
+| A testTag as the handle for a control that relocates | The tag may not exist in the expanded-toolbar layout | Device-level `UIAUTOMATOR_WITH_DESCRIPTION_CONTAINS` |
 
 ## Handling unexpected popups and system dialogs
 
@@ -475,6 +617,60 @@ Don't add popup handling logic to individual tests. If a system dialog or condit
 
 The goal is stability first, speed second. Adding conditional checks for view-blocking elements in custom commands is acceptable overhead -- it's cheaper than flaky tests.
 
+## Comments in converted tests
+
+The repo-wide "almost never comment" rule still applies to narration, but a
+converted test has two comment categories that are explicitly welcome, because
+they carry context a future reader diffing against the legacy test would otherwise
+lose:
+
+1. **Parity mapping** — how the port maps to its legacy counterpart, especially
+   any leg intentionally omitted or restructured. One or two lines.
+2. **Special-case "why"** — a brief reason for something state-specific or
+   non-obvious: why an extra navigation step is needed, why a verification is
+   implicit, why a wait or flag exists.
+
+Keep the `// Converted from legacy <Class>.<method>` header and the TestRail link.
+Cut comments that restate the code (`// Load a page, open the main menu, tap
+Bookmarks` above code doing exactly that), and don't duplicate a long parity
+explanation that already lives in the commit message — condense it.
+
+Attribute a harness gap to the gap ("no stateful BookmarksPage -> BrowserPage edge
+yet"), not to a selector or locator problem.
+
+## Diagnosing a failure before blaming a selector
+
+Reviewers and authors both waste cycles here, so it's worth stating the order.
+
+**"Not found" can mean "covered", not "absent".** On a locate failure the harness
+dumps all layers — Compose, UIAutomator, Espresso — plus a `[windows]` summary
+with window titles/types, IME and overlay flags, and the currently focused input.
+**Read `[windows]` first.** A non-APPLICATION window on top means an overlay,
+popup, or keyboard covered the target; a focused input somewhere unexpected means
+focus was stolen. Neither is a selector bug. Known blocking overlays (the Android
+stylus-handwriting prompt, for one) are auto-dismissed via `OverlayRegistry`; add
+new ones there. Web-form tests should also disable the prompt deterministically
+with `settings put secure stylus_handwriting_enabled 0` before focusing a field.
+
+**Group verification names only the first missing element.**
+`mozVerifyElementsByGroup` is an `all {}`, so it short-circuits. Expect to iterate
+once per missing member, or read the dump and check the whole group in one pass.
+
+**A retry-pass is not a pass.** `clean = false` means it failed once and passed on
+retry. During conversions that's most often an overlay rather than a product bug —
+check `[windows]` before rewriting anything.
+
+**If a fix changes nothing, suspect a second definition before your diagnosis.**
+Two separate cases produced byte-identical failures after a real fix: a duplicate
+`NavigationRegistry` edge registered in another file, and a strategy added to one
+resolution path but not the other.
+
+**Gradle's JUnit XML is authoritative** for pass/fail
+(`androidTest-results/connected/debug/TEST-*.xml`); the logcat trace explains why.
+The Test Orchestrator runs each test in its own process, so one
+`run finished: 1 tests` per test plus a suite summary is normal, not a stale
+buffer.
+
 ## Before you write: checklist
 
 1. What type of test is this? (Presence / Interaction / Behavior)
@@ -484,6 +680,9 @@ The goal is stability first, speed second. Adding conditional checks for view-bl
 5. Do the page object methods (test steps) I need already exist?
 6. For any new test step: does the method name create a meaningful `[STEP]` in the log? Would a failure at that level immediately tell you what broke?
 7. If I removed all the navigation, does the test body still make sense as a spec?
+8. If this is a conversion: have I listed every `verify*` in the legacy test **and
+   its robot helper**, and does each one have an explicit counterpart here or a
+   documented gap?
 
 ## Adding a new page
 
@@ -492,3 +691,37 @@ The goal is stability first, speed second. Adding conditional checks for view-bl
 3. Register navigation edges in `init {}`
 4. Implement `mozGetSelectorsByGroup()`
 5. Add page instance to `helpers/PageContext.kt` for use in tests
+
+Two constraints that only bite later:
+
+- **A new page object can never have an empty navigation path.** The Reachability
+  factory auto-registers every page object by reflection over `PageContext` and
+  generates a "can I reach this page?" case for each. `steps = listOf()` on the
+  only edge produces a case that always fails. If the page only exists under a
+  special launch (onboarding, for example), declare a `LaunchConfig` on its
+  `AppEntry` edge instead.
+- **`requiredForPage` must be state-invariant.** Pick something present in every
+  state — a toolbar title, never an empty-list placeholder. And if the *entry*
+  control is state-dependent (the trust-panel button's tag varies with page
+  security), the edge must `ClickIfPresent` every variant. Static checks can't see
+  either of these; verify by hand whenever you build or modify navigation.
+
+## Where the rest of the documentation lives
+
+This skill is the review rubric. The full authoring reference is in-tree and is the
+source of truth — read it there rather than trusting a copy:
+
+`mobile/android/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/efficiency/docs/`
+
+| Need | Read |
+|---|---|
+| Harness bug catalog + authoring checklist (the A*/B* entries cited above) | `docs/gotchas.md` |
+| Converting a legacy test end to end | `docs/converting-a-test.md` |
+| Architecture and layering | `docs/architecture.md` |
+| Tool inventory and what each gate runs | `docs/tooling.md` |
+| Selector discovery / authoring, page objects, navigation, BasePage, debugging | `docs/guides/` |
+
+The host-side `eff*` toolchain (`effcheck`, `effnext`, `effscaffold`, `effverify`,
+`effloop`, the `effwatch` bridge) lives in the **testops-tools** repo under
+`tae-conversion/`; see its README for setup. The device-side dump tools
+(`effview`, `effpretty`) ship in-tree under `ui/efficiency/devtools/`.


### PR DESCRIPTION
# tae: refresh test-review skill, add authoring + conversion-loop skills

Branch: `tae-skills-refresh` → `main`
Repo: `mozilla/firefox-aidev-plugins`
Reviewer: @aaronmt (CODEOWNER for `/plugins/tae/`)

## What

Expands the `tae` plugin from one skill to three, covering the full **author → review
→ land** workflow for the Fenix ui/efficiency test framework, and brings the existing
review skill current with the smoke-conversion campaign.

| Skill | Status |
|---|---|
| `tae-test-review` | Refreshed (+251 lines) |
| `efficiency-test-authoring` | New |
| `efficiency-conversion-loop` | New |

Plugin version 1.0.0 → 1.1.0. `tae` is already registered in the root
`marketplace.json`, so no change there.

## Why the review skill needed refreshing

Its primitive tables were stamped *"Verified against `helpers/BasePage.kt` on
2026-07-06"*. Since then the harness gained two selector strategies, `OverlayRegistry`
auto-dismiss, all-layer screen dumps, and eight new gotcha entries — none of it
reflected in the skill. One table entry was also actively wrong: `mozClear` was
described as internal to BasePage, but it is public.

## The substantive addition: parity audit

A review of one 13-conversion stack found **17 legacy assertions silently missing**,
and *none of them caused a failure*. `navigateToPage()` implicitly verifies the
`requiredForPage` group, which makes a legacy `verifyPageContent`/`verifyUrl` look
redundant — so it gets dropped. The navigation assertion survives; the payload
assertion disappears. The test still proves it reached a screen and stops proving the
screen is right.

The skill now makes the legacy-vs-port diff the correctness gate rather than a green
run, requires reading the legacy **robot** helper (where retry/refresh semantics hide),
and routes documented gaps into `@Converted(notes = ...)` so they persist past the
review comment.

## Other new review findings

- A new `SelectorStrategy` wired into only one of the two resolution paths
  (`resolveComposeNode()` vs `mozGetElement()`) compiles clean and fails at runtime for
  the unwired verb — now blocking.
- An `@Test` under `devtools/` without `assumeFalse(isTestLab())` consumes a Firebase
  device slot on every TAE run, because the flank config targets the whole package —
  now blocking.
- `shouldUseExpandedToolbar` relocates controls and changes the handles they expose, so
  a testTag can't be the stable handle; prefer a device-level content-description.
- Comment policy for converted tests: parity mapping and special-case "why" are
  welcome; step-by-step narration is not.
- A diagnosis order that reads the `[windows]` block before blaming a selector, since
  "not found" often means "covered by an overlay".

## Reference docs are not vendored

The seven authoring guides previously copied into the skill are byte-identical to the
ones now landed in-tree, so the skills point at
`mobile/android/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/efficiency/docs/`
instead. One source of truth, no drift. (They had already drifted once —
`discovering-selectors.md` differed by 68 lines.)

## Dependency

The host-side `eff*` toolchain the authoring and conversion-loop skills drive lives in
`mozilla-mobile/testops-tools` under `tae-conversion/` (companion PR). The review skill
needs nothing installed; authoring and review work without the toolchain, and only the
conversion loop requires it.

## Note for reviewers

`efficiency-conversion-loop` contains team-specific values (template bug, Jira story
IDs, default reviewers, Atlassian cloud). They're collected into a single
"Project-specific IDs — edit these for your team" table rather than scattered through
the prose, so another team can retarget the skill by editing one block.
