### PR TITLE
Tae skills effnext skip and paperwork

### DIFF
--- a/plugins/tae/skills/efficiency-conversion-loop/SKILL.md
+++ b/plugins/tae/skills/efficiency-conversion-loop/SKILL.md
@@ -92,6 +92,12 @@ To backfill one you already filed:
 ```json
 { "bug": "update", "ids": [NNNNN], "blocks": [2030727] }
 ```
+
+To close one as a duplicate — which happens when the same test gets converted twice, see step 1 —
+`{ "bug": "update", "ids": [NNNNN], "dupe_of": MMMMM, "self_assign": false }`. `effbug` fills in
+RESOLVED/DUPLICATE for you; passing `resolution` alone is rejected, because Bugzilla will not take
+DUPLICATE without `dupe_of`. Note there is **no** API for editing a bug's description: a wrong comment 0
+can only be fixed by a human in the web UI, so get the mechanism right before you file.
 `update` wraps relation lists as `{"add": [...]}` so this appends. Never PUT a bare list to a meta bug's
 `depends_on` — Bugzilla treats that as *replace* and it would drop every other bug the meta tracks.
 
@@ -155,6 +161,17 @@ moz-phab submit --reviewer isabel_rios --reviewer aaronmt <first-new-commit>
 `testing-exception-unchanged` tag in the Phabricator web UI (no moz-phab CLI flag exists for it). moz-phab
 keys off `Differential Revision:` trailers, so base commits that carry them are excluded automatically — even
 if they landed on autoland and aren't in your local central yet.
+
+## If you rebase a stack that is already submitted
+Dropping a commit does not remove its revision from the stack graph. Abandoning the revision leaves the
+next one still recording it as a parent, with a diff based on the commit you dropped, so the stack renders
+with an abandoned revision wedged in the middle. Resubmitting the **whole** range is what re-parents it —
+submitting only the commits whose content changed leaves the stale edge in place.
+
+Two consequences to warn the engineer about before they push: every revision gets a fresh diff, because a
+rebase changes every hash, and revisions that were already accepted reset to needs-review. If avoiding
+that churn matters more than a wording fix, leave the commit messages alone — amending one forces the
+upload you were trying to avoid.
 
 ## After landing
 Re-sync the tracker so conversion counts catch up with the `@Converted` markers that landed in step 3 (see

--- a/plugins/tae/skills/efficiency-conversion-loop/SKILL.md
+++ b/plugins/tae/skills/efficiency-conversion-loop/SKILL.md
@@ -15,12 +15,14 @@ description: >
 This skill drives the workflow *around* a conversion once the test itself is written. Test authoring
 is a separate skill (`efficiency-test-authoring`). The five steps:
 
-**convert → file bug → commit (with bug #) → track in Jira → submit for review**
+**convert → file bug (blocking meta 2030727) → annotate `@Converted` + commit (with bug #) → track in Jira
+→ submit for review**
 
 ## What runs where
 
 - **The agent (sandbox)** does the conversion, static checks, and drives the bridge; it creates Jira
-  items via the Atlassian connector. It **cannot** reach the repo, Bugzilla, or Phabricator directly.
+  items with `tools/jiratool.py` (preferred — it works headless), falling back to the Atlassian
+  connector only if that tool is unavailable. It **cannot** reach Bugzilla or Phabricator directly.
 - **The host bridge (`effwatch`)** runs the git + Bugzilla actions on the engineer's machine and returns
   results. It never pushes and never submits.
 - **The engineer** runs `effwatch`, keeps a device attached, and runs the final `moz-phab submit`.
@@ -42,6 +44,7 @@ the only values you need to change:
 | Value | Current | What it's for |
 |---|---|---|
 | Template bug | `2057054` | Cloned for product/component/version → Firefox for Android :: UI Tests |
+| Tracking meta bug | `2030727` | Every *conversion* bug must block it (`"blocks": [2030727]`) |
 | Reviewers | `isabel_rios`, `aaronmt` | Default Phabricator reviewers (`EFF_REVIEWERS`) |
 | Conversion parent | `MTE-5731` | Story that conversion sub-tasks hang off |
 | Enablement parent | `MTE-5715` (or `MTE-5688`) | Harness-hardening / tech-debt story |
@@ -67,25 +70,79 @@ Drop `conversion-runs/_queue/<id>.request.json`:
   "kind": "conversion",            // conversion | enablement | tooling — picks the description footer
   "testrail": "<id(s)>",
   "template_bug": "2057054",        // clones product/component/version → Firefox for Android :: UI Tests
+  "blocks": [2030727],              // REQUIRED for conversions — the tracking meta bug (see below)
   "type": "task" }
 ```
 `effbug` files the bug, then **rewords the title to `Bug NNNNN - <summary>`** so it matches the commit
 subject exactly, and **self-assigns** to the API-key owner. It returns the number in
 `_bug/<id>.bug-result.json`.
 
-### 3. Commit with the real bug number (agent → bridge → `effgit`)
-Write the commit message to `conversion-runs/<batch>/msg.txt` with `Bug NNNNN - [efficiency] … r=isabel_rios,aaronmt`
-then drop `{ "git":"commit", "message_file":"<batch>/msg.txt", "paths":[...] }`. (If a commit already exists
-with a placeholder, backfill by rewording — the loop files the bug *before* committing going forward, so no
-reword is needed.)
+**Hang the bug off the tracking meta bug — `"blocks": [2030727]`.**
+[Bug 2030727](https://bugzilla.mozilla.org/show_bug.cgi?id=2030727) is `[meta] TAE - Migrate and remove
+legacy tests`; it tracks the campaign via its `depends_on` list, so each conversion bug must *block* it.
+Pass `blocks` at create time — that is one field, versus a second round-trip afterwards, and a conversion
+that never gets linked is invisible to whoever reads the meta bug for campaign status.
 
-### 4. Track in Jira (agent → Atlassian connector)
+Scope: **test-conversion bugs go on the meta; tooling/docs/harness bugs do not.** The meta is specifically
+about migrating and removing legacy tests, which is why e.g. the effview-tool and harness-docs bugs are
+deliberately absent from it. If a conversion also needed harness work, the conversion bug still blocks the
+meta — the enablement is tracked in Jira (step 4), not by a second meta entry.
+
+To backfill one you already filed:
+```json
+{ "bug": "update", "ids": [NNNNN], "blocks": [2030727] }
+```
+`update` wraps relation lists as `{"add": [...]}` so this appends. Never PUT a bare list to a meta bug's
+`depends_on` — Bugzilla treats that as *replace* and it would drop every other bug the meta tracks.
+
+### 3. Commit with the real bug number (agent → bridge → `effgit`)
+
+**First annotate the legacy method(s) you just replaced — this goes in the SAME commit as the conversion,
+and it is the step most often forgotten:**
+```kotlin
+@Converted(
+    replacedBy = ["org.mozilla.fenix.ui.efficiency.tests.<Class>#<method>"],
+    bug = NNNNN,          // the bug you filed in step 2
+    since = "YYYY-MM",
+    notes = "Legacy also asserted X; not carried over because …",   // only if coverage was dropped
+)
+```
+The gate is **green locally** (step 1's `effverify` verdict), *not* landed — you cannot annotate after
+landing without a second bug and a second review, and every conversion in this campaign has landed the
+annotation alongside its replacement. `replacedBy` is required, one entry per replacement, and each must
+resolve to a real non-`@Ignore`d `@Test`. Put the parity gaps from step 1 in `notes` — that is the
+auditable record of what did not carry over. Annotate the legacy method in place; do **not** delete it, it
+keeps running alongside the replacement.
+
+Then write the commit message to `conversion-runs/<batch>/msg.txt` with
+`Bug NNNNN - [efficiency] … r=isabel_rios,aaronmt` and drop
+`{ "git":"commit", "message_file":"<batch>/msg.txt", "paths":[...] }` — the `paths` list must include the
+legacy test file you just annotated as well as the new/changed efficiency files. (If a commit already
+exists with a placeholder, backfill by rewording — the loop files the bug *before* committing going
+forward, so no reword is needed. `effgit`'s `amend` does **not** stage: send `stage` first, then `amend`.)
+
+### 4. Track in Jira (agent → `jiratool.py`)
 Separate strict conversion from the enablement it sometimes forces, so conversion effort can be measured:
 - **Conversion** → a **Sub-task labelled `conversion`** under the Smoke-conversion campaign story **MTE-5731**.
 - **Tooling/enablement** discovered during conversion → a **separate Sub-task labelled `enablement`** under
   Harness Hardening **MTE-5715** (or Tech-Debt **MTE-5688**), **linked** ("Relates") to the conversion sub-task.
-- Create with `issueTypeName: "Sub-task"`, `additional_fields: {"labels":[...]}`, and self-assign via
-  `assignee_account_id`. Put the bug number + Phab revision in the item. cloudId = `mozilla-hub.atlassian.net`.
+- Put the bug number, branch/commit and Phab revision in the item.
+
+Use `tools/jiratool.py` (works headless; no Atlassian connector needed). Bodies come from a file, so write
+the description to a temp file first:
+```
+python3 jiratool.py create '<summary>' --file body.txt --parent MTE-5731 --issuetype Sub-task --label conversion
+python3 jiratool.py create '<summary>' --file body.txt --parent MTE-5715 --issuetype Sub-task --label enablement
+python3 jiratool.py link <enablement-key> Relates <conversion-key>
+python3 jiratool.py assign <key> --me        # create does NOT self-assign; do this explicitly
+```
+`create` defaults to `--issuetype Story` and no labels, so pass both every time or the item lands as an
+unlabelled Story in the wrong shape. `--label` is repeatable. If the Atlassian MCP connector happens to be
+connected it also works, but do not count on it — it is absent in headless/cron runs.
+
+An enablement sub-task is warranted whenever the conversion needed a *new* page object, selector twin, nav
+edge or `moz*`/`mozVerify*` primitive — i.e. build mode 3. Write up what the gap was and what the proper
+fix would be, not just the workaround you shipped.
 
 ### 5. Submit the finished stack (engineer)
 Submitting/landing stays with the engineer. **Mozilla's moz-phab has no `--dry-run`** — it's interactive: it
@@ -100,10 +157,11 @@ keys off `Differential Revision:` trailers, so base commits that carry them are 
 if they landed on autoland and aren't in your local central yet.
 
 ## After landing
-Re-sync the tracker so conversion counts + `@Converted` annotations catch up (see
-`tae-conversion/README.md` → "Reconciling the ledger" and `tae-conversion/tools/reconcile_conversion.py`),
-and annotate the converted legacy methods with `@Converted(replacedBy = [...], bug = NNNNN, since = "YYYY-MM")`
-once green + landed. Record any coverage that didn't carry over in the annotation's `notes` parameter.
+Re-sync the tracker so conversion counts catch up with the `@Converted` markers that landed in step 3 (see
+`tae-conversion/README.md` → "Reconciling the ledger" and `tae-conversion/tools/reconcile_conversion.py`).
+
+If reconcile reports a converted test with no `@Converted` marker, the annotation was missed in step 3 —
+that is a gap to backfill under a follow-up bug, not the normal path. Annotating is step 3's job.
 
 ## Conventions
 - **Faithful-port-first:** don't rewrite behavior during conversion; log quality ideas separately.

--- a/plugins/tae/skills/efficiency-test-authoring/SKILL.md
+++ b/plugins/tae/skills/efficiency-test-authoring/SKILL.md
@@ -65,9 +65,13 @@ Work the gates in order. At each gate you either compose with what exists or add
 then continue. Navigation is the spine — resolve reachability first. Lean on the tools (below); they
 make each gate faster and safer than doing it by hand.
 
-0. **Pick the next test (local, no network).** Run `effnext --json` — next unconverted candidate(s) from
-   the local prioritized pool minus what's done. **Never call the Google Sheet to choose** — it's slow and
-   the local pool is the working queue. (The Sheet is systems-of-record for status, not the per-test picker.)
+0. **Pick the next test (local, no network).** Run `effnext --json` — next candidate(s) from the local
+   prioritized pool minus what's done, minus skips, minus anything whose method already exists in the
+   efficiency tests package. **Never call the Google Sheet to choose** — it's slow and the local pool is the
+   working queue. (The Sheet is systems-of-record for status, not the per-test picker.) If the pick isn't one
+   to take now — too complex for whoever is picking it up, blocked on a harness gap, deliberately deferred —
+   record that rather than stepping over it: `effnext --skip Class.method --reason "…"` parks it (reversible
+   with `--unskip`; it never marks the test converted) and prints the new next pick.
 1. **Scaffold + extract intent.** Run `effscaffold <Class.method> --json` first — it pulls the legacy
    body, TestRail id, whether an efficiency test of that name already exists (don't re-convert!), the
    robots + their selector lines, and which screens are already modeled. From that, write the
@@ -80,7 +84,13 @@ make each gate faster and safer than doing it by hand.
    or page-object helper — new verbs go through `resolve()` and keep its guarantees (exception-safe
    presence, preserve per-strategy Compose tree). → `docs/guides/extending-basepage.md`.
 4. **Assertion gate.** Verifications expressible (`mozVerify*` family)? If not, add a verify primitive.
-   → `docs/guides/extending-basepage.md`.
+   → `docs/guides/extending-basepage.md`. Two traps worth knowing before you assert on anything you also
+   click: a disabled Compose button still *accepts* the click gesture and silently skips `onClick`, so
+   "clicked" in the report does not mean the app acted; and an enabled-check against a `COMPOSE_BY_TEXT`
+   selector is a no-op, because it resolves the text node inside the button (which reports enabled while the
+   button is disabled) — use `COMPOSE_BY_TEXT_MERGED` for anything you act on. Prefer a positive assertion
+   over waiting for something to disappear: absence cannot tell "it worked" from "the click was dropped".
+   See HARNESS-GOTCHAS A16/A17.
 5. **Static pre-flight.** Run `effcheck … --json` before spending a device build — it catches string/id
    resolution, empty nav paths (gotcha B1), inline selectors (B2), missing BasePage verbs, and
    test-class boilerplate (MWS/IMP). Fix everything it flags first.
@@ -102,8 +112,9 @@ make each gate faster and safer than doing it by hand.
    (`verifyPageContent`, `verifyUrl`, a tab count) rather than the navigation. Never justify an omission
    with "`navigateToPage` already checks it" — an implicit assertion can't be audited. If you omit a leg
    (e.g. no stateful return edge), **log it as a harness gap** in the test and the commit message — don't
-   silently drop it. THEN annotate the legacy test with `@Converted` (only after green + landed — the
-   burndown keys off it):
+   silently drop it. THEN annotate the legacy test with `@Converted`. The gate is **green locally** (gate 6's
+   `effverify` verdict); annotate it **in the same commit as the conversion** — never defer this to a
+   post-landing pass, which would need a second bug and a second review:
    ```kotlin
    @Converted(
        replacedBy = ["org.mozilla.fenix.ui.efficiency.tests.AutofillTest#verifyAddressAutofillTest"],
@@ -114,8 +125,10 @@ make each gate faster and safer than doing it by hand.
    ```
    `replacedBy` is required and every entry must resolve to a real, non-`@Ignore`d `@Test` (validated by
    the conversion lint check). Use `notes` for coverage that intentionally did not carry over — that's the
-   mechanism the parity rule above asks for. The legacy test keeps running alongside the replacement until
-   the replacement has been green on main for the configured cadence.
+   mechanism the parity rule above asks for. Annotate the legacy method **in place** — do not delete or
+   `@Ignore` it; it keeps running alongside the replacement, and the annotation is what the burndown counts.
+   Check the annotation is actually in your staged diff before committing: a conversion that lands without
+   it looks unconverted to the ledger, and this is the single most-missed step in the loop.
 8. **Land it.** Hand off to the **efficiency-conversion-loop** skill for bug → commit → Jira → submit.
 9. **Feedback.** Recurring shape (nav→click→verify) → flag as a factory candidate. Every new
    assumption-correction → add to `CONVERSION-LESSONS.md`; if it changes the workflow, update this skill.
@@ -124,7 +137,7 @@ make each gate faster and safer than doing it by hand.
 
 | Tool | Use at | Does |
 |---|---|---|
-| `effnext` | gate 0 | Next unconverted candidate(s) from the local pool minus done. Local-only, no network. `--json`. |
+| `effnext` | gate 0 | Next candidate(s): pool minus done, minus skips, minus what's already in-tree. `--skip`/`--unskip`/`--skips`. Local-only, no network. `--json`. |
 | `effscaffold` | gate 1 | Legacy body, TestRail, already-converted check, robots+selectors, existing coverage. |
 | `effdump` / `ScreenDump` | gate 2 | Dumps a screen's real handles in all 3 layers (Compose / Espresso / UIAutomator). Author from ground truth, not stubs. |
 | `effcheck` | gate 5 | Static pre-flight (no device) — resolution, nav, inline selectors, verbs, boilerplate. |

--- a/plugins/tae/skills/efficiency-test-authoring/SKILL.md
+++ b/plugins/tae/skills/efficiency-test-authoring/SKILL.md
@@ -72,6 +72,10 @@ make each gate faster and safer than doing it by hand.
    to take now — too complex for whoever is picking it up, blocked on a harness gap, deliberately deferred —
    record that rather than stepping over it: `effnext --skip Class.method --reason "…"` parks it (reversible
    with `--unskip`; it never marks the test converted) and prints the new next pick.
+   **Fetch main before you pick.** Both `effnext`'s in-tree filter and `effscaffold`'s already-converted
+   check read *your checkout*, so a branch that predates someone else's landing cannot see their
+   conversion — and the duplicate then surfaces as a rebase conflict after review and submission, which is
+   how bug 2060292 ended up duplicating bug 2060174.
 1. **Scaffold + extract intent.** Run `effscaffold <Class.method> --json` first — it pulls the legacy
    body, TestRail id, whether an efficiency test of that name already exists (don't re-convert!), the
    robots + their selector lines, and which screens are already modeled. From that, write the

--- a/plugins/tae/skills/efficiency-test-authoring/SKILL.md
+++ b/plugins/tae/skills/efficiency-test-authoring/SKILL.md
@@ -142,7 +142,7 @@ make each gate faster and safer than doing it by hand.
 | `effdump` / `ScreenDump` | gate 2 | Dumps a screen's real handles in all 3 layers (Compose / Espresso / UIAutomator). Author from ground truth, not stubs. |
 | `effcheck` | gate 5 | Static pre-flight (no device) — resolution, nav, inline selectors, verbs, boilerplate. |
 | `effbuild` | gate 6 | Compile verdict + only the error lines. `--json`. Read this, not the raw build log. |
-| `effverify` | gate 6 | Done-gate (scoped to the **last** run): `ok`/`clean`, `failed_total`, `runs`, `retried`, and a capped `failure_excerpt` on failure. `--json` — the agent reads THIS, never the raw report. |
+| `effverify` | gate 6 | Done-gate (aggregates **every** run block, not just the last): `ok`/`clean`, `failed_total`, `runs`, `retried`, per-test `status` incl. `retry-pass`, and a capped `failure_excerpt` on failure. `--json` — the agent reads THIS, never the raw report. |
 | `effpretty` | (human) | Renders the `Eff` run log for a **person** inspecting a run. Not part of the agent's read path. |
 | effwatch bridge | gate 6 | Runs the build/run on the engineer's device and returns reports. |
 


### PR DESCRIPTION
# tae: correct the conversion loop's paperwork steps and document effnext's skip flow

Three documentation changes to the `tae` skills, all from running the conversion loop end to end on a real stack. Two of them correct instructions that were actively wrong; the third documents new tooling.

**Depends on the companion `testops-tools` PR** (`tae-conversion-toolchain-fixes`) — it adds the `effnext` flags described here and the `effverify` behaviour this corrects. Land that one first so these skills don't reference flags that don't exist yet.

## 1. Paperwork the loop was getting wrong (`efficiency-conversion-loop`)

Three rules, each of which cost rework on the most recent stack:

- **Conversion bugs must block the tracking meta (2030727), set at create time.** The meta tracks the campaign through its `depends_on` list, so a conversion bug that never gets linked is invisible to anyone reading it for status. Two bugs on the last stack were caught unlinked during a pre-submit audit. Scope matters too: tooling, docs and harness bugs stay *off* the meta, since it is specifically about migrating and removing legacy tests. Includes the backfill form, and a warning never to PUT a bare list to a meta's `depends_on` — Bugzilla treats that as *replace*, which would silently drop every other bug it tracks.
- **`@Converted` goes in the same commit as the conversion**, gated on green locally rather than on landing. The burndown keys off that marker, so a conversion landing without it reads as unconverted; annotating afterwards needs a second bug and a second review. On the last stack this was missed on two conversions and required a mid-stack rewrite to fix properly. The commit's `paths` list must include the annotated legacy file.
- **Jira goes through `tools/jiratool.py`**, which works headless, rather than the Atlassian connector, which is absent in headless and cron runs. Notes that `create` defaults to `Story` with no labels and does not self-assign, so all three have to be passed explicitly.

## 2. effnext's skip flow (`efficiency-test-authoring`, gate 0)

Whoever picks up the queue may not be in a position to take the next candidate — too complex for them, blocked on a harness gap, or deliberately deferred by whoever is sequencing the campaign. There was no way to say so, so the decision lived in someone's head and the next caller got the same pick.

Gate 0 and the tool table now describe `--skip Class.method --reason "…"`, `--unskip`, and `--skips`, including the property that makes them safe to use casually: a skip never marks a test converted.

The same entry documents the new in-tree filter. The done-ledger lags the tree — it proposed a test that was already converted *and committed*, and 11 of its top 30 candidates were already in-tree — so `effnext` now drops candidates whose method already exists in the efficiency tests package. Worth knowing that `effscaffold`'s `already_converted` does not cover this: it matches files, not methods, which is how the stale pick got past gate 1.

## 3. Two traps at the assertion gate (`efficiency-test-authoring`)

From bug 2060405, both of which cost a long debugging session:

- A disabled Compose button still **accepts the click gesture** and silently skips `onClick`, so "clicked" in the report means the gesture was delivered, not that the app acted. The failure then surfaces wherever the effect was expected — in that case 25 seconds and several steps later.
- An enabled-check against a `COMPOSE_BY_TEXT` selector is a **no-op**, because it resolves the text node inside the button, which reports enabled while the button is disabled. Use `COMPOSE_BY_TEXT_MERGED` for anything you act on.

Plus the rule that falls out of both: prefer a positive assertion over waiting for something to disappear, since absence cannot distinguish "it worked" from "the click was dropped".

## 4. effverify's scope was documented as its own bug

The tool table said the done-gate is *"scoped to the **last** run"*. That was the defect, not the contract: `effloop` emits one run block per test after the class run, so reading only the last block reported passing tests as `not-run`, genuinely failed tests as `failed_total: 0`, and `retried: false` across a run containing eight of them.

`effverify` now aggregates every block and reports a per-test status including `retry-pass`. Documenting the broken behaviour as intended is worse than not documenting it — an agent would trust a verdict the tool no longer produces, and have no reason to question a green that came from the wrong block.

## Notes

Documentation only; no plugin code changes. The rules here are not proposals — each one is the corrected version of something that went wrong on the four-commit Fenix stack these skills drove, which shipped two conversions, two harness fixes, and a full-suite sweep of 42 efficiency classes / 137 tests.
